### PR TITLE
upgrade postgres to v18 which has performance benefits and native uuid7 support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   postgres:
-    image: postgres:17.6
+    image: postgres:18.0
     container_name: laa-postgres
     restart: unless-stopped
     ports:


### PR DESCRIPTION
Since we're early into the project and likely don't have much data, to run just delete the existing docker volume