### PR TITLE
chore: Updates global exception handler for better error handling

### DIFF
--- a/data-access-api/build.gradle
+++ b/data-access-api/build.gradle
@@ -49,6 +49,7 @@ openApiGenerate {
             useJakartaEe        : "true",
             useSpringBoot3      : "true",
             useTags             : "true",
+            useBeanValidation   : "false"
     ]
     globalProperties = [
             models              : "", // omitting `supportingFiles` prevents generation of

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/exception/GlobalExceptionHandler.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/exception/GlobalExceptionHandler.java
@@ -15,15 +15,20 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
+
+/**
+ * The global exception handler for all exceptions.
+ */
 @RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
-  @PostConstruct
-  public void init() {
-    log.info("GlobalExceptionHandler loaded!");
-  }
-
+  /**
+   * The handler for ApplicationNotFoundException.
+   *
+   * @param ex the exception.
+   * @return the response with exception message.
+   */
   @ExceptionHandler(ApplicationNotFoundException.class)
   public ResponseEntity<ProblemDetail> handleApplicationNotFound(ApplicationNotFoundException ex) {
     ProblemDetail pd = ProblemDetail.forStatus(NOT_FOUND);
@@ -32,6 +37,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(NOT_FOUND).body(pd);
   }
 
+  /**
+   * The handler for CaseworkerNotFoundException.
+   *
+   * @param ex the exception.
+   * @return the response with exception message.
+   */
   @ExceptionHandler(CaseworkerNotFoundException.class)
   public ResponseEntity<ProblemDetail> handleCaseworkerNotFound(CaseworkerNotFoundException ex) {
     ProblemDetail pd = ProblemDetail.forStatus(NOT_FOUND);
@@ -40,6 +51,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(NOT_FOUND).body(pd);
   }
 
+  /**
+   * The handler for ValidationException.
+   *
+   * @param ex the exception.
+   * @return the response with errors.
+   */
   @ExceptionHandler(ValidationException.class)
   public ResponseEntity<ProblemDetail> handleValidationException(ValidationException ex) {
     ProblemDetail pd = ProblemDetail.forStatus(BAD_REQUEST);
@@ -49,6 +66,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest().body(pd);
   }
 
+  /**
+   * Handles deserialization errors due to malformed types (like sending an Object instead of String).
+   *
+   * @param ex the exception.
+   * @return the response with a descriptive error message.
+   */
   @ExceptionHandler(HttpMessageNotReadableException.class)
   public ResponseEntity<ProblemDetail> handleMalformedJson(HttpMessageNotReadableException ex) {
     Throwable root = ex.getRootCause();
@@ -75,6 +98,12 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest().body(pd);
   }
 
+  /**
+   * The handler for all other exceptions.
+   *
+   * @param ex the exception.
+   * @return the response with fixed title and detail.
+   */
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ProblemDetail> handleGenericException(Exception ex) {
     log.error("An unexpected application error has occurred.", ex);

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/exception/GlobalExceptionHandler.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
@@ -98,6 +99,16 @@ public class GlobalExceptionHandler {
     return ResponseEntity.badRequest().body(pd);
   }
 
+  /**
+   * The handler for AuthorizationDeniedException.
+   *
+   * @param exception the exception.
+   */
+  @ExceptionHandler(AuthorizationDeniedException.class)
+  public void handleAuthorizationDeniedException(AuthorizationDeniedException exception)
+      throws AuthorizationDeniedException {
+    throw exception;
+  }
   /**
    * The handler for all other exceptions.
    *


### PR DESCRIPTION
## What

POC updates to our validations to catch malformed payloads.

Not to be merged, just used to showcase the potential of the functionality

## The tests

```
curl -i -X POST http://localhost:8080/api/v0/applications \
-H 'Content-Type: application/json' \
-d '{
    "status": "IN_PROGRESS",
    "applicationContent": {
        "caseType": "Housing",
        "mockData": true
    },
    "applicationReference": {}, 
    "individuals": [
        { 
            "firstName": "Alice", 
            "lastName": "Smith", 
            "dateOfBirth": "1985-10-25", 
            "details": {
                "addressLine1": "123 Mock Lane"
            } 
        }
    ]
}'
```


- Current code:

```
HTTP/1.1 400 
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/problem+json
Transfer-Encoding: chunked
Date: Thu, 11 Dec 2025 12:59:46 GMT
Connection: close

{"type":"about:blank","title":"Bad Request","status":400,"detail":"Failed to read request","instance":"/api/v0/applications"}% 
```

- `useBeanValidation=false` only

In build.gradle -> configOptions -> useBeanValidation : “false”
./gradlew openApiGenerate
./gradlew clean build

```
HTTP/1.1 400 
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/problem+json
Transfer-Encoding: chunked
Date: Thu, 11 Dec 2025 13:09:19 GMT
Connection: close

{"type":"about:blank","title":"Bad Request","status":400,"detail":"Failed to read request","instance":"/api/v0/applications"}%  
```
- `useBeanValidation=false` + `GlobalExceptionHandler` updated (this branch)

```
HTTP/1.1 400 
X-Content-Type-Options: nosniff
X-XSS-Protection: 0
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/problem+json
Transfer-Encoding: chunked
Date: Thu, 11 Dec 2025 16:13:40 GMT
Connection: close

{"type":"about:blank","title":"Bad Request","status":400,"detail":"Invalid data type for field 'applicationReference'. Expected String.","instance":"/api/v0/applications"}%   
```