### PR TITLE
Feature/dstew 1221 add certificate to decision endpoint

### DIFF
--- a/data-access-api/open-api-application-specification.yml
+++ b/data-access-api/open-api-application-specification.yml
@@ -730,3 +730,6 @@ components:
           $ref: "#/components/schemas/EventHistory"
         autoGranted:
           type: boolean
+        certificate:
+          type: object
+          description: Certificate information (required when overallDecision is GRANTED)

--- a/data-access-api/open-api-application-specification.yml
+++ b/data-access-api/open-api-application-specification.yml
@@ -732,4 +732,5 @@ components:
           type: boolean
         certificate:
           type: object
+          additionalProperties: true
           description: Certificate information (required when overallDecision is GRANTED)

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationMakeDecisionTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationMakeDecisionTest.java
@@ -32,7 +32,9 @@ import uk.gov.justice.laa.dstew.access.utils.TestConstants;
 import uk.gov.justice.laa.dstew.access.utils.generator.DataGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.application.ApplicationEntityGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.application.ApplicationMakeDecisionRequestGenerator;
+import uk.gov.justice.laa.dstew.access.utils.generator.certificate.CertificateContentGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.proceeding.ProceedingsEntityGenerator;
+import uk.gov.justice.laa.dstew.access.utils.testDto.certificate.CertificateContent;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -571,10 +573,7 @@ public class ApplicationMakeDecisionTest extends BaseIntegrationTest {
         ProceedingEntity proceedingEntity = persistedDataGenerator.createAndPersist(ProceedingsEntityGenerator.class,
                 builder -> builder.applicationId(applicationEntity.getId()));
 
-        Map<String, Object> certificateData = new HashMap<>();
-        certificateData.put("certificateNumber", "TESTCERT001");
-        certificateData.put("issueDate", "2026-03-03");
-        certificateData.put("validUntil", "2027-03-03");
+        CertificateContent expectedCertificateContent = DataGenerator.createDefault(CertificateContentGenerator.class);
 
         MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, builder -> {
             builder
@@ -586,7 +585,7 @@ public class ApplicationMakeDecisionTest extends BaseIntegrationTest {
                     .proceedings(List.of(
                             createMakeDecisionProceeding(proceedingEntity.getId(), MeritsDecisionStatus.GRANTED, "justification 1", "reason 1")
                     ))
-                    .certificate(certificateData)
+                    .certificate(objectMapper.convertValue(expectedCertificateContent, Map.class))
                     .autoGranted(false);
         });
 

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationMakeDecisionTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationMakeDecisionTest.java
@@ -15,6 +15,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MvcResult;
 import uk.gov.justice.laa.dstew.access.entity.ApplicationEntity;
+import uk.gov.justice.laa.dstew.access.entity.CertificateEntity;
 import uk.gov.justice.laa.dstew.access.entity.DecisionEntity;
 import uk.gov.justice.laa.dstew.access.entity.MeritsDecisionEntity;
 import uk.gov.justice.laa.dstew.access.entity.ProceedingEntity;
@@ -461,6 +462,7 @@ public class ApplicationMakeDecisionTest extends BaseIntegrationTest {
         Assertions.assertThat(actual)
                 .usingRecursiveComparison()
                 .ignoringCollectionOrder()
+                .ignoringFields("certificate")
                 .isEqualTo(expectedMakeDecisionRequest);
 
         Assertions.assertThat(savedDecision.getModifiedAt()).isNotNull();
@@ -504,5 +506,205 @@ public class ApplicationMakeDecisionTest extends BaseIntegrationTest {
                 .reason(entity.getReason())
                 .justification(entity.getJustification())
                 .build();
+    }
+
+    @Test
+    @WithMockUser(authorities = TestConstants.Roles.WRITER)
+    public void givenGrantedDecisionWithNoCertificate_whenAssignDecision_thenReturnBadRequest()
+            throws Exception {
+        // given
+        ApplicationEntity applicationEntity = persistedDataGenerator.createAndPersist(ApplicationEntityGenerator.class, builder -> {
+            builder.applicationContent(new HashMap<>(Map.of(
+                    "test", "content"
+            )));
+            builder.status(ApplicationStatus.APPLICATION_SUBMITTED);
+        });
+
+        ProceedingEntity proceedingEntity = persistedDataGenerator.createAndPersist(ProceedingsEntityGenerator.class,
+                builder -> builder.applicationId(applicationEntity.getId()));
+
+        MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, builder -> {
+            builder
+                    .userId(CaseworkerJohnDoe.getId())
+                    .eventHistory(EventHistory.builder()
+                            .eventDescription("granted event")
+                            .build())
+                    .overallDecision(DecisionStatus.GRANTED)
+                    .proceedings(List.of(
+                            createMakeDecisionProceeding(proceedingEntity.getId(), MeritsDecisionStatus.GRANTED, "justification 1", "reason 1")
+                    ))
+                    .certificate(null)
+                    .autoGranted(false);
+        });
+
+        // when
+        MvcResult result = patchUri(TestConstants.URIs.ASSIGN_DECISION, makeDecisionRequest, applicationEntity.getId());
+
+        // then
+        assertSecurityHeaders(result);
+        assertNoCacheHeaders(result);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), result.getResponse().getStatus());
+        assertEquals("application/problem+json", result.getResponse().getContentType());
+
+        ProblemDetail problemDetail = deserialise(result, ProblemDetail.class);
+        @SuppressWarnings("unchecked")
+        List<String> errors = (List<String>) problemDetail.getProperties().get("errors");
+        Assertions.assertThat(errors).contains("The Make Decision request must contain a certificate when overallDecision is GRANTED");
+
+        // Verify no certificate was persisted
+        List<CertificateEntity> certificates = certificateRepository.findAll();
+        assertThat(certificates.size()).isEqualTo(0);
+    }
+
+    @Test
+    @WithMockUser(authorities = TestConstants.Roles.WRITER)
+    public void givenGrantedDecisionWithCertificate_whenAssignDecision_thenReturnNoContent_andDecisionAndCertificateSaved()
+            throws Exception {
+        // given
+        ApplicationEntity applicationEntity = persistedDataGenerator.createAndPersist(ApplicationEntityGenerator.class, builder -> {
+            builder.applicationContent(new HashMap<>(Map.of(
+                    "test", "content"
+            )));
+            builder.status(ApplicationStatus.APPLICATION_SUBMITTED);
+        });
+
+        ProceedingEntity proceedingEntity = persistedDataGenerator.createAndPersist(ProceedingsEntityGenerator.class,
+                builder -> builder.applicationId(applicationEntity.getId()));
+
+        Map<String, Object> certificateData = new HashMap<>();
+        certificateData.put("certificateNumber", "TESTCERT001");
+        certificateData.put("issueDate", "2026-03-03");
+        certificateData.put("validUntil", "2027-03-03");
+
+        MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, builder -> {
+            builder
+                    .userId(CaseworkerJohnDoe.getId())
+                    .eventHistory(EventHistory.builder()
+                            .eventDescription("granted event")
+                            .build())
+                    .overallDecision(DecisionStatus.GRANTED)
+                    .proceedings(List.of(
+                            createMakeDecisionProceeding(proceedingEntity.getId(), MeritsDecisionStatus.GRANTED, "justification 1", "reason 1")
+                    ))
+                    .certificate(certificateData)
+                    .autoGranted(false);
+        });
+
+        // when
+        MvcResult result = patchUri(TestConstants.URIs.ASSIGN_DECISION, makeDecisionRequest, applicationEntity.getId());
+
+        // then
+        assertSecurityHeaders(result);
+        assertNoCacheHeaders(result);
+        assertNoContent(result);
+
+        ApplicationEntity updatedApplicationEntity = applicationRepository.findById(applicationEntity.getId()).orElseThrow();
+        assertEquals(ApplicationStatus.APPLICATION_SUBMITTED, updatedApplicationEntity.getStatus());
+        assertEquals(false, updatedApplicationEntity.getIsAutoGranted());
+        assertThat(decisionRepository.countById(updatedApplicationEntity.getDecision().getId())).isEqualTo(1);
+
+        verifyDecisionSavedCorrectly(
+                applicationEntity.getId(),
+                makeDecisionRequest
+        );
+
+        // Verify certificate was persisted
+        List<CertificateEntity> certificates = certificateRepository.findAll();
+        assertThat(certificates.size()).isEqualTo(1);
+
+        CertificateEntity certificate = certificates.get(0);
+        assertThat(certificate.getApplicationId()).isEqualTo(applicationEntity.getId());
+        assertThat(certificate.getCertificateContent()).isNotNull();
+        assertThat(certificate.getCertificateContent().get("certificateNumber")).isEqualTo("TESTCERT001");
+        assertThat(certificate.getCertificateContent().get("issueDate")).isEqualTo("2026-03-03");
+        assertThat(certificate.getCertificateContent().get("validUntil")).isEqualTo("2027-03-03");
+        assertThat(certificate.getCreatedBy()).isEqualTo(CaseworkerJohnDoe.getId().toString());
+        assertThat(certificate.getUpdatedBy()).isEqualTo(CaseworkerJohnDoe.getId().toString());
+        assertThat(certificate.getCreatedAt()).isNotNull();
+        assertThat(certificate.getModifiedAt()).isNotNull();
+    }
+
+    @Test
+    @WithMockUser(authorities = TestConstants.Roles.WRITER)
+    public void givenRefusedDecisionWithNoCertificate_whenAssignDecision_thenReturnNoContent()
+            throws Exception {
+        // given
+        ApplicationEntity applicationEntity = persistedDataGenerator.createAndPersist(ApplicationEntityGenerator.class, builder -> {
+            builder.applicationContent(new HashMap<>(Map.of(
+                    "test", "content"
+            )));
+            builder.status(ApplicationStatus.APPLICATION_SUBMITTED);
+        });
+
+        ProceedingEntity proceedingEntity = persistedDataGenerator.createAndPersist(ProceedingsEntityGenerator.class,
+                builder -> builder.applicationId(applicationEntity.getId()));
+
+        MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, builder -> {
+            builder
+                    .userId(CaseworkerJohnDoe.getId())
+                    .eventHistory(EventHistory.builder()
+                            .eventDescription("refusal event")
+                            .build())
+                    .overallDecision(DecisionStatus.REFUSED)
+                    .proceedings(List.of(
+                            createMakeDecisionProceeding(proceedingEntity.getId(), MeritsDecisionStatus.REFUSED, "justification 1", "reason 1")
+                    ))
+                    .certificate(null)
+                    .autoGranted(false);
+        });
+
+        // when
+        MvcResult result = patchUri(TestConstants.URIs.ASSIGN_DECISION, makeDecisionRequest, applicationEntity.getId());
+
+        // then
+        assertSecurityHeaders(result);
+        assertNoCacheHeaders(result);
+        assertNoContent(result);
+
+        // Verify no certificate was persisted
+        List<CertificateEntity> certificates = certificateRepository.findAll();
+        assertThat(certificates.size()).isEqualTo(0);
+    }
+
+    @Test
+    @WithMockUser(authorities = TestConstants.Roles.WRITER)
+    public void givenPartiallyGrantedDecisionWithNoCertificate_whenAssignDecision_thenReturnNoContent()
+            throws Exception {
+        // given
+        ApplicationEntity applicationEntity = persistedDataGenerator.createAndPersist(ApplicationEntityGenerator.class, builder -> {
+            builder.applicationContent(new HashMap<>(Map.of(
+                    "test", "content"
+            )));
+            builder.status(ApplicationStatus.APPLICATION_SUBMITTED);
+        });
+
+        ProceedingEntity proceedingEntity = persistedDataGenerator.createAndPersist(ProceedingsEntityGenerator.class,
+                builder -> builder.applicationId(applicationEntity.getId()));
+
+        MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, builder -> {
+            builder
+                    .userId(CaseworkerJohnDoe.getId())
+                    .eventHistory(EventHistory.builder()
+                            .eventDescription("partially granted event")
+                            .build())
+                    .overallDecision(DecisionStatus.PARTIALLY_GRANTED)
+                    .proceedings(List.of(
+                            createMakeDecisionProceeding(proceedingEntity.getId(), MeritsDecisionStatus.GRANTED, "justification 1", "reason 1")
+                    ))
+                    .certificate(null)
+                    .autoGranted(false);
+        });
+
+        // when
+        MvcResult result = patchUri(TestConstants.URIs.ASSIGN_DECISION, makeDecisionRequest, applicationEntity.getId());
+
+        // then
+        assertSecurityHeaders(result);
+        assertNoCacheHeaders(result);
+        assertNoContent(result);
+
+        // Verify no certificate was persisted (only GRANTED requires certificate)
+        List<CertificateEntity> certificates = certificateRepository.findAll();
+        assertThat(certificates.size()).isEqualTo(0);
     }
 }

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationMakeDecisionTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationMakeDecisionTest.java
@@ -607,12 +607,15 @@ public class ApplicationMakeDecisionTest extends BaseIntegrationTest {
                 makeDecisionRequest
         );
 
-        // Verify certificate was persisted
+        verifyCertificateSavedCorrectly(applicationEntity.getId());
+    }
+
+    private void verifyCertificateSavedCorrectly(UUID applicationId) {
         List<CertificateEntity> certificates = certificateRepository.findAll();
         assertThat(certificates.size()).isEqualTo(1);
 
         CertificateEntity certificate = certificates.get(0);
-        assertThat(certificate.getApplicationId()).isEqualTo(applicationEntity.getId());
+        assertThat(certificate.getApplicationId()).isEqualTo(applicationId);
         assertThat(certificate.getCertificateContent()).isNotNull();
         assertThat(certificate.getCertificateContent().get("certificateNumber")).isEqualTo("TESTCERT001");
         assertThat(certificate.getCertificateContent().get("issueDate")).isEqualTo("2026-03-03");

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/repository/CertificateRepositoryTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/repository/CertificateRepositoryTest.java
@@ -1,0 +1,39 @@
+package uk.gov.justice.laa.dstew.access.repository;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.dstew.access.entity.CertificateEntity;
+import uk.gov.justice.laa.dstew.access.entity.ApplicationEntity;
+import uk.gov.justice.laa.dstew.access.utils.BaseIntegrationTest;
+import uk.gov.justice.laa.dstew.access.utils.generator.application.ApplicationEntityGenerator;
+import uk.gov.justice.laa.dstew.access.utils.generator.certificate.CertificateEntityGenerator;
+
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class CertificateRepositoryTest extends BaseIntegrationTest {
+
+    @Test
+    public void givenSaveOfExpectedCertificate_whenGetCalled_expectedAndActualAreEqual() {
+
+        // given
+        ApplicationEntity applicationEntity = persistedDataGenerator.createAndPersist(ApplicationEntityGenerator.class);
+        CertificateEntity expected = persistedDataGenerator.createAndPersist(CertificateEntityGenerator.class,
+                builder -> builder.applicationId(applicationEntity.getId()));
+        clearCache();
+
+        // when
+        CertificateEntity actual = certificateRepository.findById(expected.getId()).orElse(null);
+
+        // then
+        assertCertificateEqual(expected, actual);
+    }
+
+    private void assertCertificateEqual(CertificateEntity expected, CertificateEntity actual) {
+        assertThat(expected)
+                .usingRecursiveComparison()
+                .ignoringFields("createdAt", "modifiedAt")
+                .isEqualTo(actual);
+        assertThat(expected.getCreatedAt()).isNotNull();
+        assertThat(expected.getModifiedAt()).isNotNull();
+    }
+}

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/utils/BaseIntegrationTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/utils/BaseIntegrationTest.java
@@ -34,6 +34,7 @@ import uk.gov.justice.laa.dstew.access.model.Individual;
 import uk.gov.justice.laa.dstew.access.model.MakeDecisionRequest;
 import uk.gov.justice.laa.dstew.access.repository.ApplicationRepository;
 import uk.gov.justice.laa.dstew.access.repository.CaseworkerRepository;
+import uk.gov.justice.laa.dstew.access.repository.CertificateRepository;
 import uk.gov.justice.laa.dstew.access.repository.DomainEventRepository;
 import uk.gov.justice.laa.dstew.access.repository.DecisionRepository;
 import uk.gov.justice.laa.dstew.access.repository.IndividualRepository;
@@ -78,6 +79,9 @@ public abstract class BaseIntegrationTest {
 
     @Autowired
     protected DecisionRepository decisionRepository;
+
+    @Autowired
+    protected CertificateRepository certificateRepository;
 
     @Autowired
     protected ApplicationAsserts applicationAsserts;

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/utils/generator/PersistedDataGenerator.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/utils/generator/PersistedDataGenerator.java
@@ -10,6 +10,7 @@ import uk.gov.justice.laa.dstew.access.repository.*;
 import uk.gov.justice.laa.dstew.access.utils.generator.application.ApplicationEntityGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.application.ApplicationSummaryGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.caseworker.CaseworkerGenerator;
+import uk.gov.justice.laa.dstew.access.utils.generator.certificate.CertificateEntityGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.decision.DecisionEntityGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.domainEvent.DomainEventGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.merit.MeritsDecisionsEntityGenerator;
@@ -43,6 +44,7 @@ public class PersistedDataGenerator extends DataGenerator {
         registerRepository(ProceedingsEntityGenerator.class, ProceedingRepository.class);
         registerRepository(MeritsDecisionsEntityGenerator.class, MeritsDecisionRepository.class);
         registerRepository(IndividualGenerator.class, IndividualRepository.class);
+        registerRepository(CertificateEntityGenerator.class, CertificateRepository.class);
     }
 
     public <TGenerator, TRepository extends JpaRepository<?, ?>>

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/repository/CertificateRepository.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/repository/CertificateRepository.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.laa.dstew.access.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import uk.gov.justice.laa.dstew.access.entity.CertificateEntity;
+
+/**
+ * Repository for managing Certificate entities.
+ */
+@Repository
+public interface CertificateRepository extends JpaRepository<CertificateEntity, UUID> {
+}

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
@@ -353,7 +353,8 @@ public class ApplicationService {
   @PreAuthorize("@entra.hasAppRole('ApplicationWriter')")
   public void makeDecision(final UUID applicationId, final MakeDecisionRequest request) {
     final ApplicationEntity application = checkIfApplicationExists(applicationId);
-    checkIfCaseworkerExists(request.getUserId());
+    final UUID userId = request.getUserId();
+    checkIfCaseworkerExists(userId);
 
     applicationValidations.checkApplicationMakeDecisionRequest(request);
 
@@ -407,12 +408,11 @@ public class ApplicationService {
           new TypeReference<>() {}
       );
 
-      String userId = request.getUserId().toString();
       CertificateEntity certificate = CertificateEntity.builder()
           .applicationId(applicationId)
           .certificateContent(certificateContent)
-          .createdBy(userId)
-          .updatedBy(userId)
+          .createdBy(String.valueOf(userId))
+          .updatedBy(String.valueOf(userId))
           .build();
 
       certificateRepository.save(certificate);

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
@@ -403,14 +403,9 @@ public class ApplicationService {
 
     // Persist certificate if overallDecision is GRANTED
     if (decision.getOverallDecision() == DecisionStatus.GRANTED && request.getCertificate() != null) {
-      Map<String, Object> certificateContent = objectMapper.convertValue(
-          request.getCertificate(),
-          new TypeReference<>() {}
-      );
-
       CertificateEntity certificate = CertificateEntity.builder()
           .applicationId(applicationId)
-          .certificateContent(certificateContent)
+          .certificateContent(request.getCertificate())
           .createdBy(String.valueOf(userId))
           .updatedBy(String.valueOf(userId))
           .build();

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/service/ApplicationService.java
@@ -18,6 +18,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.dstew.access.entity.ApplicationEntity;
 import uk.gov.justice.laa.dstew.access.entity.CaseworkerEntity;
+import uk.gov.justice.laa.dstew.access.entity.CertificateEntity;
 import uk.gov.justice.laa.dstew.access.entity.DecisionEntity;
 import uk.gov.justice.laa.dstew.access.entity.MeritsDecisionEntity;
 import uk.gov.justice.laa.dstew.access.entity.ProceedingEntity;
@@ -35,6 +36,7 @@ import uk.gov.justice.laa.dstew.access.model.MakeDecisionRequest;
 import uk.gov.justice.laa.dstew.access.model.MeritsDecisionStatus;
 import uk.gov.justice.laa.dstew.access.repository.ApplicationRepository;
 import uk.gov.justice.laa.dstew.access.repository.CaseworkerRepository;
+import uk.gov.justice.laa.dstew.access.repository.CertificateRepository;
 import uk.gov.justice.laa.dstew.access.repository.DecisionRepository;
 import uk.gov.justice.laa.dstew.access.repository.MeritsDecisionRepository;
 import uk.gov.justice.laa.dstew.access.repository.ProceedingRepository;
@@ -58,6 +60,7 @@ public class ApplicationService {
   private final DecisionRepository decisionRepository;
   private final ProceedingRepository proceedingRepository;
   private final MeritsDecisionRepository meritsDecisionRepository;
+  private final CertificateRepository certificateRepository;
   private final ProceedingsService proceedingsService;
   private final PayloadValidationService payloadValidationService;
 
@@ -79,6 +82,7 @@ public class ApplicationService {
                             final ApplicationContentParserService applicationContentParserService,
                             final ProceedingRepository proceedingRepository,
                             final MeritsDecisionRepository meritsDecisionRepository,
+                            final CertificateRepository certificateRepository,
                             final ProceedingsService proceedingsService, PayloadValidationService payloadValidationService) {
     this.applicationRepository = applicationRepository;
     this.applicationMapper = applicationMapper;
@@ -93,6 +97,7 @@ public class ApplicationService {
     this.domainEventService = domainEventService;
     this.decisionRepository = decisionRepository;
     this.meritsDecisionRepository = meritsDecisionRepository;
+    this.certificateRepository = certificateRepository;
   }
 
   /**
@@ -378,6 +383,24 @@ public class ApplicationService {
     decision.setOverallDecision(DecisionStatus.valueOf(request.getOverallDecision().getValue()));
     decision.setModifiedAt(Instant.now());
     decisionRepository.save(decision);
+
+    // Persist certificate if overallDecision is GRANTED
+    if (decision.getOverallDecision() == DecisionStatus.GRANTED && request.getCertificate() != null) {
+      Map<String, Object> certificateContent = objectMapper.convertValue(
+          request.getCertificate(),
+          new TypeReference<>() {}
+      );
+
+      String userId = request.getUserId().toString();
+      CertificateEntity certificate = CertificateEntity.builder()
+          .applicationId(applicationId)
+          .certificateContent(certificateContent)
+          .createdBy(userId)
+          .updatedBy(userId)
+          .build();
+
+      certificateRepository.save(certificate);
+    }
 
     if (decision.getOverallDecision() == DecisionStatus.REFUSED) {
       domainEventService.saveMakeDecisionRefusedDomainEvent(

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/validation/ApplicationValidations.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/validation/ApplicationValidations.java
@@ -1,12 +1,13 @@
 package uk.gov.justice.laa.dstew.access.validation;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import uk.gov.justice.laa.dstew.access.entity.MeritsDecisionEntity;
 import uk.gov.justice.laa.dstew.access.model.ApplicationUpdateRequest;
+import uk.gov.justice.laa.dstew.access.model.DecisionStatus;
 import uk.gov.justice.laa.dstew.access.model.MakeDecisionRequest;
 import uk.gov.justice.laa.dstew.access.model.MeritsDecisionDetails;
 import uk.gov.justice.laa.dstew.access.shared.security.EffectiveAuthorizationProvider;
@@ -62,6 +63,13 @@ public class ApplicationValidations {
       );
     }
 
+    // Validate certificate is provided when overallDecision is GRANTED
+    if (dto.getOverallDecision() == DecisionStatus.GRANTED && isCertificateNullOrEmpty(dto.getCertificate())) {
+      throw new ValidationException(
+              List.of("The Make Decision request must contain a certificate when overallDecision is GRANTED")
+      );
+    }
+
     dto.getProceedings().forEach(proceeding -> {
       MeritsDecisionDetails mdd = proceeding.getMeritsDecision();
       if (mdd.getReason() == null || mdd.getReason().isEmpty()) {
@@ -75,5 +83,15 @@ public class ApplicationValidations {
                         + proceeding.getProceedingId()));
       }
     });
+  }
+
+  private boolean isCertificateNullOrEmpty(Object certificate) {
+    if (certificate == null) {
+      return true;
+    }
+    if (certificate instanceof Map) {
+      return ((Map<?, ?>) certificate).isEmpty();
+    }
+    return certificate.toString().isEmpty();
   }
 }

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/AccessAppTests.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/AccessAppTests.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.laa.dstew.access;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
@@ -10,6 +9,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.justice.laa.dstew.access.repository.ApplicationRepository;
 import uk.gov.justice.laa.dstew.access.repository.ApplicationSummaryRepository;
 import uk.gov.justice.laa.dstew.access.repository.CaseworkerRepository;
+import uk.gov.justice.laa.dstew.access.repository.CertificateRepository;
 import uk.gov.justice.laa.dstew.access.repository.DomainEventRepository;
 import uk.gov.justice.laa.dstew.access.repository.DecisionRepository;
 import uk.gov.justice.laa.dstew.access.repository.IndividualRepository;
@@ -42,6 +42,9 @@ public class AccessAppTests {
 
   @MockitoBean
   private MeritsDecisionRepository meritsDecisionRepository;
+
+  @MockitoBean
+  private CertificateRepository certificateRepository;
 
   @MockitoBean
   private IndividualRepository individualRepository;

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/application/MakeDecisionForApplicationTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/application/MakeDecisionForApplicationTest.java
@@ -49,6 +49,8 @@ import uk.gov.justice.laa.dstew.access.utils.generator.decision.DecisionEntityGe
 import uk.gov.justice.laa.dstew.access.utils.generator.merit.MeritsDecisionsEntityGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.merit.MeritsDecisionDetailsGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.proceeding.MakeDecisionProceedingGenerator;
+import uk.gov.justice.laa.dstew.access.utils.generator.certificate.CertificateContentGenerator;
+import uk.gov.justice.laa.dstew.access.utils.testDto.certificate.CertificateContent;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
 
 /**
@@ -698,9 +700,8 @@ public class MakeDecisionForApplicationTest extends BaseServiceTest {
         builder.id(caseworkerId)
     );
 
-    Map<String, Object> certificateData = new HashMap<>();
-    certificateData.put("certificateNumber", "TESTCERT001");
-    certificateData.put("issueDate", "2026-03-03");
+    CertificateContent certificateContent = DataGenerator.createDefault(CertificateContentGenerator.class);
+    Map<String, Object> certificateData = objectMapper.convertValue(certificateContent, Map.class);
 
     MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, requestBuilder ->
         requestBuilder

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/application/MakeDecisionForApplicationTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/application/MakeDecisionForApplicationTest.java
@@ -635,6 +635,169 @@ public class MakeDecisionForApplicationTest extends BaseServiceTest {
             .hasMessageContaining(unrelatedApplicationProceedingId.toString());
   }
 
+  @Test
+  void givenGrantedDecisionWithoutCertificate_whenMakeDecision_thenValidationExceptionThrown() {
+    // given
+    UUID applicationId = UUID.randomUUID();
+    UUID proceedingId = UUID.randomUUID();
+    CaseworkerEntity caseworker = DataGenerator.createDefault(CaseworkerGenerator.class);
+
+    MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, requestBuilder ->
+        requestBuilder
+            .userId(caseworker.getId())
+            .overallDecision(DecisionStatus.GRANTED)
+            .eventHistory(EventHistory.builder()
+                .eventDescription("granted event")
+                .build())
+            .proceedings(List.of(
+                createMakeDecisionProceedingDetails(proceedingId, MeritsDecisionStatus.GRANTED, "justification", "reason")
+            ))
+            .certificate(null)
+    );
+
+    ApplicationEntity applicationEntity = DataGenerator.createDefault(ApplicationEntityGenerator.class, builder ->
+        builder
+            .id(applicationId)
+            .applicationContent(new HashMap<>(Map.of("test", "content")))
+            .caseworker(caseworker)
+    );
+
+    ProceedingEntity proceedingEntity = DataGenerator.createDefault(ProceedingsEntityGenerator.class, builder ->
+        builder.id(proceedingId).applicationId(applicationId)
+    );
+
+    setSecurityContext(TestConstants.Roles.WRITER);
+
+    when(caseworkerRepository.findById(caseworker.getId())).thenReturn(Optional.of(caseworker));
+    when(proceedingRepository.findAllById(List.of(proceedingId))).thenReturn(List.of(proceedingEntity));
+    when(applicationRepository.findById(applicationId)).thenReturn(Optional.of(applicationEntity));
+
+    // when
+    Throwable thrown = catchThrowable(() ->
+        serviceUnderTest.makeDecision(applicationId, makeDecisionRequest)
+    );
+
+    // then
+    assertThat(thrown).isInstanceOf(ValidationException.class);
+    ValidationException validationException = (ValidationException) thrown;
+    assertThat(validationException.errors())
+        .contains("The Make Decision request must contain a certificate when overallDecision is GRANTED");
+
+    verify(certificateRepository, never()).save(any());
+    verify(applicationRepository, times(1)).findById(applicationId);
+    verify(applicationRepository, never()).save(any());
+  }
+
+  @Test
+  void givenGrantedDecisionWithCertificate_whenMakeDecision_thenCertificateSaved() {
+    // given
+    UUID applicationId = UUID.randomUUID();
+    UUID proceedingId = UUID.randomUUID();
+    UUID caseworkerId = UUID.randomUUID();
+    CaseworkerEntity caseworker = DataGenerator.createDefault(CaseworkerGenerator.class, builder ->
+        builder.id(caseworkerId)
+    );
+
+    Map<String, Object> certificateData = new HashMap<>();
+    certificateData.put("certificateNumber", "TESTCERT001");
+    certificateData.put("issueDate", "2026-03-03");
+
+    MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, requestBuilder ->
+        requestBuilder
+            .userId(caseworkerId)
+            .overallDecision(DecisionStatus.GRANTED)
+            .eventHistory(EventHistory.builder()
+                .eventDescription("granted event")
+                .build())
+            .proceedings(List.of(
+                createMakeDecisionProceedingDetails(proceedingId, MeritsDecisionStatus.GRANTED, "justification", "reason")
+            ))
+            .certificate(certificateData)
+    );
+
+    ApplicationEntity applicationEntity = DataGenerator.createDefault(ApplicationEntityGenerator.class, builder ->
+        builder
+            .id(applicationId)
+            .applicationContent(new HashMap<>(Map.of("test", "content")))
+            .caseworker(caseworker)
+    );
+
+    ProceedingEntity proceedingEntity = DataGenerator.createDefault(ProceedingsEntityGenerator.class, builder ->
+        builder.id(proceedingId).applicationId(applicationId)
+    );
+
+    setSecurityContext(TestConstants.Roles.WRITER);
+
+    when(caseworkerRepository.findById(caseworker.getId())).thenReturn(Optional.of(caseworker));
+    when(proceedingRepository.findAllById(List.of(proceedingId))).thenReturn(List.of(proceedingEntity));
+    when(applicationRepository.findById(applicationId)).thenReturn(Optional.of(applicationEntity));
+
+    // when
+    serviceUnderTest.makeDecision(applicationId, makeDecisionRequest);
+
+    // then
+    ArgumentCaptor<uk.gov.justice.laa.dstew.access.entity.CertificateEntity> certificateCaptor =
+        ArgumentCaptor.forClass(uk.gov.justice.laa.dstew.access.entity.CertificateEntity.class);
+    verify(certificateRepository, times(1)).save(certificateCaptor.capture());
+
+    uk.gov.justice.laa.dstew.access.entity.CertificateEntity savedCertificate = certificateCaptor.getValue();
+    assertThat(savedCertificate.getApplicationId()).isEqualTo(applicationId);
+    assertThat(savedCertificate.getCertificateContent()).isEqualTo(certificateData);
+    assertThat(savedCertificate.getCreatedBy()).isEqualTo(caseworkerId.toString());
+    assertThat(savedCertificate.getUpdatedBy()).isEqualTo(caseworkerId.toString());
+
+    verify(applicationRepository, times(1)).findById(applicationId);
+    verify(applicationRepository, times(2)).save(any(ApplicationEntity.class));
+    verify(domainEventRepository, never()).save(any(DomainEventEntity.class));
+  }
+
+  @Test
+  void givenRefusedDecisionWithoutCertificate_whenMakeDecision_thenNoCertificateSaved() {
+    // given
+    UUID applicationId = UUID.randomUUID();
+    UUID proceedingId = UUID.randomUUID();
+    CaseworkerEntity caseworker = DataGenerator.createDefault(CaseworkerGenerator.class);
+
+    MakeDecisionRequest makeDecisionRequest = DataGenerator.createDefault(ApplicationMakeDecisionRequestGenerator.class, requestBuilder ->
+        requestBuilder
+            .userId(caseworker.getId())
+            .overallDecision(DecisionStatus.REFUSED)
+            .eventHistory(EventHistory.builder()
+                .eventDescription("refusal event")
+                .build())
+            .proceedings(List.of(
+                createMakeDecisionProceedingDetails(proceedingId, MeritsDecisionStatus.REFUSED, "justification", "reason")
+            ))
+            .certificate(null)
+    );
+
+    ApplicationEntity applicationEntity = DataGenerator.createDefault(ApplicationEntityGenerator.class, builder ->
+        builder
+            .id(applicationId)
+            .applicationContent(new HashMap<>(Map.of("test", "content")))
+            .caseworker(caseworker)
+    );
+
+    ProceedingEntity proceedingEntity = DataGenerator.createDefault(ProceedingsEntityGenerator.class, builder ->
+        builder.id(proceedingId).applicationId(applicationId)
+    );
+
+    setSecurityContext(TestConstants.Roles.WRITER);
+
+    when(caseworkerRepository.findById(caseworker.getId())).thenReturn(Optional.of(caseworker));
+    when(proceedingRepository.findAllById(List.of(proceedingId))).thenReturn(List.of(proceedingEntity));
+    when(applicationRepository.findById(applicationId)).thenReturn(Optional.of(applicationEntity));
+
+    // when
+    serviceUnderTest.makeDecision(applicationId, makeDecisionRequest);
+
+    // then
+    verify(certificateRepository, never()).save(any());
+    verify(applicationRepository, times(1)).findById(applicationId);
+    verify(applicationRepository, times(2)).save(any(ApplicationEntity.class));
+    verify(domainEventRepository, times(1)).save(any(DomainEventEntity.class));
+  }
+
   private DecisionEntity createDecisionEntityWithProceeding(
           UUID proceedingId,
           MeritsDecisionStatus decision,

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/utils/BaseServiceTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/utils/BaseServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.justice.laa.dstew.access.repository.ApplicationRepository;
 import uk.gov.justice.laa.dstew.access.repository.ApplicationSummaryRepository;
 import uk.gov.justice.laa.dstew.access.repository.CaseworkerRepository;
+import uk.gov.justice.laa.dstew.access.repository.CertificateRepository;
 import uk.gov.justice.laa.dstew.access.repository.DecisionRepository;
 import uk.gov.justice.laa.dstew.access.repository.DomainEventRepository;
 import uk.gov.justice.laa.dstew.access.repository.IndividualRepository;
@@ -70,6 +71,9 @@ public class BaseServiceTest {
 
     @MockitoBean
     protected MeritsDecisionRepository meritsDecisionRepository;
+
+    @MockitoBean
+    protected CertificateRepository certificateRepository;
 
     @MockitoBean
     protected IndividualRepository individualRepository;

--- a/data-access-service/src/testUtilities/java/uk/gov/justice/laa/dstew/access/utils/generator/certificate/CertificateContentGenerator.java
+++ b/data-access-service/src/testUtilities/java/uk/gov/justice/laa/dstew/access/utils/generator/certificate/CertificateContentGenerator.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.laa.dstew.access.utils.generator.certificate;
+
+import uk.gov.justice.laa.dstew.access.utils.generator.BaseGenerator;
+import uk.gov.justice.laa.dstew.access.utils.testDto.certificate.CertificateContent;
+
+public class CertificateContentGenerator extends
+  BaseGenerator<CertificateContent, CertificateContent.CertificateContentBuilder> {
+
+  public CertificateContentGenerator() {
+      super(CertificateContent::toBuilder, CertificateContent.CertificateContentBuilder::build);
+  }
+
+  @Override
+  public CertificateContent createDefault() {
+    return CertificateContent.builder()
+        .certificateNumber("TESTCERT001")
+        .issueDate("2026-03-03")
+        .validUntil("2027-03-03")
+        .build();
+  }
+}

--- a/data-access-service/src/testUtilities/java/uk/gov/justice/laa/dstew/access/utils/generator/certificate/CertificateEntityGenerator.java
+++ b/data-access-service/src/testUtilities/java/uk/gov/justice/laa/dstew/access/utils/generator/certificate/CertificateEntityGenerator.java
@@ -1,0 +1,31 @@
+package uk.gov.justice.laa.dstew.access.utils.generator.certificate;
+
+import java.util.Map;
+import java.util.UUID;
+import uk.gov.justice.laa.dstew.access.entity.CertificateEntity;
+import uk.gov.justice.laa.dstew.access.utils.generator.BaseGenerator;
+import uk.gov.justice.laa.dstew.access.utils.generator.DataGenerator;
+import uk.gov.justice.laa.dstew.access.utils.testDto.certificate.CertificateContent;
+
+public class CertificateEntityGenerator extends BaseGenerator<CertificateEntity, CertificateEntity.CertificateEntityBuilder> {
+
+    public CertificateEntityGenerator() {
+        super(CertificateEntity::toBuilder, CertificateEntity.CertificateEntityBuilder::build);
+    }
+
+    @Override
+    public CertificateEntity createDefault() {
+        CertificateContent content = DataGenerator.createDefault(CertificateContentGenerator.class);
+
+        return CertificateEntity.builder()
+                .applicationId(UUID.randomUUID())
+                .certificateContent(Map.of(
+                        "certificateNumber", content.getCertificateNumber(),
+                        "issueDate", content.getIssueDate(),
+                        "validUntil", content.getValidUntil()
+                ))
+                .createdBy("test-user")
+                .updatedBy("test-user")
+                .build();
+    }
+}

--- a/data-access-service/src/testUtilities/java/uk/gov/justice/laa/dstew/access/utils/testDto/certificate/CertificateContent.java
+++ b/data-access-service/src/testUtilities/java/uk/gov/justice/laa/dstew/access/utils/testDto/certificate/CertificateContent.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.laa.dstew.access.utils.testDto.certificate;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder(toBuilder = true)
+@Getter
+@Setter
+public class CertificateContent {
+  public String certificateNumber;
+  public String issueDate;
+  public String validUntil;
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1221)

Extend the Application Decision Api endpoint to include a certificate property which is required when `overallDecision` is `GRANTED`.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
