### PR TITLE
feat: office code as property of provider

### DIFF
--- a/data-access-api/open-api-application-specification.yml
+++ b/data-access-api/open-api-application-specification.yml
@@ -476,6 +476,12 @@ components:
           items:
             $ref: "#/components/schemas/Opponent"
         provider:
+          $ref: "#/components/schemas/Provider"
+
+    Provider:
+      type: object
+      properties:
+        officeCode:
           type: string
 
     ApplicationCreateRequest:

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/GetApplicationTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/GetApplicationTest.java
@@ -7,8 +7,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.ActiveProfiles;
@@ -18,9 +16,9 @@ import uk.gov.justice.laa.dstew.access.entity.DecisionEntity;
 import uk.gov.justice.laa.dstew.access.model.Application;
 import uk.gov.justice.laa.dstew.access.model.ApplicationStatus;
 import uk.gov.justice.laa.dstew.access.model.DecisionStatus;
+import uk.gov.justice.laa.dstew.access.model.Provider;
 import uk.gov.justice.laa.dstew.access.utils.BaseIntegrationTest;
 import uk.gov.justice.laa.dstew.access.utils.TestConstants;
-import uk.gov.justice.laa.dstew.access.utils.builders.HttpHeadersBuilder;
 import uk.gov.justice.laa.dstew.access.utils.generator.application.ApplicationEntityGenerator;
 import uk.gov.justice.laa.dstew.access.utils.generator.decision.DecisionEntityGenerator;
 
@@ -298,7 +296,11 @@ public class GetApplicationTest extends BaseIntegrationTest {
             application.setOverallDecision(applicationEntity.getDecision().getOverallDecision());
         }
         application.isLead(applicationEntity.isLead());
-        application.setProvider(applicationEntity.getOfficeCode());
+        application.setProvider(
+            applicationEntity.getOfficeCode() != null
+                ? new Provider().officeCode(applicationEntity.getOfficeCode())
+                : null
+        );
         return application;
     }
 }

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/mapper/ApplicationMapper.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/mapper/ApplicationMapper.java
@@ -24,6 +24,7 @@ import uk.gov.justice.laa.dstew.access.model.ApplicationUpdateRequest;
 import uk.gov.justice.laa.dstew.access.model.Individual;
 import uk.gov.justice.laa.dstew.access.model.Opponent;
 import uk.gov.justice.laa.dstew.access.model.OpponentDetails;
+import uk.gov.justice.laa.dstew.access.model.Provider;
 
 /**
  * Mapper interface.
@@ -109,7 +110,11 @@ public interface ApplicationMapper {
     application.setOpponents(
         extractOpponents(entity.getApplicationContent())
     );
-    application.setProvider(entity.getOfficeCode());
+    application.setProvider(
+        entity.getOfficeCode() != null
+            ? new Provider().officeCode(entity.getOfficeCode())
+            : null
+    );
 
     return application;
   }

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/mapper/ApplicationMapperTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/mapper/ApplicationMapperTest.java
@@ -22,6 +22,7 @@ import uk.gov.justice.laa.dstew.access.model.ApplicationUpdateRequest;
 import uk.gov.justice.laa.dstew.access.model.Individual;
 import uk.gov.justice.laa.dstew.access.model.Opponent;
 import uk.gov.justice.laa.dstew.access.model.Proceeding;
+import uk.gov.justice.laa.dstew.access.model.Provider;
 
 class ApplicationMapperTest {
 
@@ -58,7 +59,7 @@ class ApplicationMapperTest {
         assertThat(actualApplication.getLaaReference()).isEqualTo(laaReference);
         assertThat(actualApplication.getStatus()).isEqualTo(status);
         assertThat(actualApplication.getLastUpdated()).isEqualTo(OffsetDateTime.ofInstant(updatedAt, ZoneOffset.UTC));
-        assertThat(actualApplication.getProvider()).isEqualTo(officeCode);
+        assertThat(actualApplication.getProvider()).isEqualTo(new Provider().officeCode(officeCode));
     }
 
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1213)

Resolves an error - makes it: 
`"provider": {
   "officeCode" : "string"
  }`
instead of provider being assigned office code

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
