### PR TITLE
feat(DSTEW-1544): configure local instance of prometheus and grafana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Generated local monitoring dashboard (source of truth is the Helm template) ###
+infra/grafana/provisioning/dashboards/laa-data-access-api.json

--- a/.helm/data-access-api/templates/deployment.yaml
+++ b/.helm/data-access-api/templates/deployment.yaml
@@ -66,3 +66,5 @@ spec:
             {{ include "sentryConfig" . | nindent 12 }}
             - name: SLOW_QUERY_THRESHOLD_SECONDS
               value: "{{ .Values.slowQueryThresholdSeconds | default 0 }}"
+            - name: METRICS_RELEASE_TAG
+              value: "{{ .Release.Name }}"

--- a/data-access-service/src/main/resources/application.yml
+++ b/data-access-service/src/main/resources/application.yml
@@ -66,6 +66,8 @@ management:
   endpoint.health.show-details: always
   info.env.enabled: true
   metrics:
+    tags:
+      release: ${METRICS_RELEASE_TAG:local}
     distribution:
       percentile-histogram:
         jdbc.query: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,29 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  prometheus:
+    image: prom/prometheus:v3.2.1
+    container_name: laa-prometheus
+    restart: unless-stopped
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:11.6.0
+    container_name: laa-grafana
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+
 volumes:
   pgdata:

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -133,6 +133,49 @@ The Grafana dashboard includes the following panel groups:
 2. Ensure all new PromQL queries include the appropriate release/pod filter
 3. Deploy and verify in UAT before merging
 
+> After editing the template, re-run `scripts/generate-local-dashboard.sh` to keep the local dashboard in sync.
+
+## Running Prometheus & Grafana locally
+
+Prometheus and Grafana are included in `docker-compose.yml` and are configured to scrape a Spring Boot dev server running on your machine.
+
+**Prerequisites**
+
+1. Generate the local dashboard JSON (the Helm template is the source of truth):
+   ```bash
+   bash scripts/generate-local-dashboard.sh
+   ```
+   Re-run this whenever `.helm/data-access-api/templates/grafana-dashboard-template.json` changes.
+
+2. Start your Spring Boot application locally (default port `8080`).
+
+**Start the monitoring stack**
+
+```bash
+docker compose up prometheus grafana
+```
+
+Or start everything at once (DB + monitoring):
+
+```bash
+docker compose up
+```
+
+| Service | URL | Default credentials |
+|---|---|---|
+| Prometheus | http://localhost:9090 | — |
+| Grafana | http://localhost:3000 | admin / admin |
+
+Confirm Prometheus is scraping your app at `http://localhost:9090/targets` — the `laa-data-access-api` job should show **UP**.
+
+**How it works**
+
+The local Prometheus scrapes `/actuator/prometheus` on `host.docker.internal:8080` and attaches static labels `release=local`, `namespace=local`, and `container=data-access-api`. The app emits the `release=local` tag via Micrometer (controlled by the `METRICS_RELEASE_TAG` environment variable, which defaults to `local` and is overridden to the Helm release name in k8s deployments). The dashboard filters on these labels, so all panels work without modification.
+
+**Panels not available locally**
+
+The "Service Stats" panels that query `kube_pod_container_info` and `kube_pod_status_phase` require kube-state-metrics and will show no data. All other panels (HTTP, SQL, JVM, entity operations) work fully.
+
 ## Troubleshooting
 
 | Problem | Likely cause | Fix |

--- a/infra/grafana/provisioning/dashboards/dashboard-provider.yml
+++ b/infra/grafana/provisioning/dashboards/dashboard-provider.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/infra/grafana/provisioning/datasources/prometheus.yml
+++ b/infra/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    url: http://prometheus:9090
+    access: proxy
+    isDefault: true
+    editable: false

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: laa-data-access-api
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - host.docker.internal:8080
+        labels:
+          release: local
+          namespace: local
+          container: data-access-api

--- a/scripts/generate-local-dashboard.sh
+++ b/scripts/generate-local-dashboard.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SOURCE="$REPO_ROOT/.helm/data-access-api/templates/grafana-dashboard-template.json"
+DEST="$REPO_ROOT/infra/grafana/provisioning/dashboards/laa-data-access-api.json"
+
+python3 - "$SOURCE" "$DEST" <<'PYTHON'
+import sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# Strip the Helm define/end wrapper (first and last non-empty lines)
+lines = content.split('\n')
+# Remove the opening {{- define ... -}} line
+lines = lines[1:]
+# Strip trailing empty lines and the closing {{- end -}} line
+while lines and lines[-1].strip() in ('', '{{- end -}}'):
+    lines.pop()
+content = '\n'.join(lines) + '\n'
+
+replacements = [
+    # UID field (uses Helm pipe functions — handle before the simpler patterns)
+    (
+        '{{ .Release.Name | trunc 12 }}-{{ .Release.Namespace | trunc -10 }}-{{ .Chart.Name | trunc -12 }}',
+        'local'
+    ),
+    # $container template variable: replace kube-only query with a locally available metric
+    (
+        'label_values(kube_pod_container_info{namespace=\\"{{ .Release.Namespace }}\\", pod=~\\"{{ .Release.Name }}.*\\"},container)',
+        'label_values(http_server_requests_seconds_count{release=\\"local\\"}, container)'
+    ),
+    # Standard Helm release/chart variables
+    ('{{ .Release.Name }}', 'local'),
+    ('{{ .Release.Namespace }}', 'local'),
+    ('{{ .Chart.Name }}', 'data-access-api'),
+    # Unescape Grafana template variables that Helm wraps in backtick literals
+    ('{{`{{app}}`}}', '{{app}}'),
+    ('{{`{{instance}}`}}', '{{instance}}'),
+    ('{{`{{operation_type}}`}}', '{{operation_type}}'),
+    ('{{`{{entity}}`}}', '{{entity}}'),
+    ('{{`{{operation}}`}}', '{{operation}}'),
+]
+
+for old, new in replacements:
+    content = content.replace(old, new)
+
+with open(sys.argv[2], 'w') as f:
+    f.write(content)
+
+print(f"Generated: {sys.argv[2]}")
+PYTHON


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1544)

This pull request adds a complete local monitoring stack using Prometheus and Grafana, making it easy to observe the application's metrics during development. It introduces Docker Compose services for Prometheus and Grafana, provides configuration for both tools, ensures the application emits a consistent `release` tag for metrics, and documents how to run and use the stack locally. Additionally, a script is added to generate a local Grafana dashboard from the Helm template, ensuring the dashboard matches the production configuration.

**Local Monitoring Stack**

* Added `prometheus` and `grafana` services to `docker-compose.yml`, enabling local metrics collection and dashboarding.
* Added Prometheus configuration (`infra/prometheus/prometheus.yml`) to scrape the Spring Boot app and label metrics appropriately.
* Added Grafana provisioning files for dashboards and Prometheus datasource (`infra/grafana/provisioning/dashboards/dashboard-provider.yml`, `infra/grafana/provisioning/datasources/prometheus.yml`). [[1]](diffhunk://#diff-3dbcb44cc8802316239725ee5941406cd6dc8a9004375bd7ee9f405e48347ea0R1-R11) [[2]](diffhunk://#diff-5f6d97aedd87082fb799dbaeb800fcb00b10db57e15389998dbea54c361d102cR1-R10)

**Application Metrics Tagging**

* Updated the Helm deployment (`.helm/data-access-api/templates/deployment.yaml`) to set a `METRICS_RELEASE_TAG` environment variable, and configured Micrometer in `application.yml` to emit a `release` tag, defaulting to `local` for local runs. [[1]](diffhunk://#diff-369fa7ee6680aff68cb36f8e94437bfca6834a7731fcdc08c2ce7f30287d852bR69-R70) [[2]](diffhunk://#diff-f04fc1e666849c3f5068df08d1ee2744631f82fe3f37d166ca5dbc6b08db6345R69-R70)

**Dashboard Synchronization and Documentation**

* Added `scripts/generate-local-dashboard.sh` to generate a local Grafana dashboard JSON from the Helm template, ensuring local dashboards match production.
* Updated `docs/monitoring.md` with instructions for running Prometheus and Grafana locally, including how the setup works and its limitations.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test integrationTest`
- [x] CheckStyle should not error: `./gradlew checkStyleMain`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
