### PR TITLE
feat: rename overallDecision to decisionStatus in get application details

### DIFF
--- a/data-access-api/open-api-application-specification.yml
+++ b/data-access-api/open-api-application-specification.yml
@@ -607,7 +607,7 @@ components:
           type: boolean
         autoGrant:
           type: boolean
-        overallDecision:
+        decisionStatus:
           $ref: "#/components/schemas/DecisionStatus"
         applicationType:
           $ref: "#/components/schemas/ApplicationType"

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/GetApplicationTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/GetApplicationTest.java
@@ -340,7 +340,7 @@ public class GetApplicationTest extends BaseHarnessTest {
     application.setUsedDelegatedFunctions(applicationEntity.getUsedDelegatedFunctions());
     application.setAutoGrant(applicationEntity.getIsAutoGranted());
     if (applicationEntity.getDecision() != null) {
-      application.setOverallDecision(applicationEntity.getDecision().getOverallDecision());
+      application.setDecisionStatus(applicationEntity.getDecision().getOverallDecision());
     }
     application.isLead(applicationEntity.isLead());
 

--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/sharedAsserts/ApplicationAsserts.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/sharedAsserts/ApplicationAsserts.java
@@ -97,7 +97,7 @@ public class ApplicationAsserts {
     application.setUsedDelegatedFunctions(applicationEntity.getUsedDelegatedFunctions());
     application.setAutoGrant(applicationEntity.getIsAutoGranted());
     if (applicationEntity.getDecision() != null) {
-      application.setOverallDecision(applicationEntity.getDecision().getOverallDecision());
+      application.setDecisionStatus(applicationEntity.getDecision().getOverallDecision());
     }
     return application;
   }

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/mapper/ApplicationMapper.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/mapper/ApplicationMapper.java
@@ -103,7 +103,7 @@ public interface ApplicationMapper {
     application.setUsedDelegatedFunctions(entity.getUsedDelegatedFunctions());
     application.setAutoGrant(entity.getIsAutoGranted());
     if (entity.getDecision() != null) {
-      application.setOverallDecision(entity.getDecision().getOverallDecision());
+      application.setDecisionStatus(entity.getDecision().getOverallDecision());
     }
     application.setApplicationType(ApplicationType.INITIAL);
     application.setOpponents(extractOpponents(entity.getApplicationContent()));

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/application/GetApplicationTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/application/GetApplicationTest.java
@@ -135,6 +135,12 @@ public class GetApplicationTest extends BaseServiceTest {
     assertThat(actualApplication.getStatus()).isEqualTo(expectedApplication.getStatus());
     assertThat(actualApplication.getLaaReference())
         .isEqualTo(expectedApplication.getLaaReference());
+    if (expectedApplication.getDecision() != null) {
+      assertThat(actualApplication.getDecisionStatus())
+          .isEqualTo(expectedApplication.getDecision().getOverallDecision());
+    } else {
+      assertThat(actualApplication.getDecisionStatus()).isNull();
+    }
   }
 
   private void assertApplicationProceedingsEqual(


### PR DESCRIPTION

## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1470)

Renames the property `overallDecision` to `decisionStatus` in `GET /applications/{id}`. Updates tests.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
