### PR TITLE
DSTEW-1546 - Configure Renovate to regenerate Gradle lockfiles and add wait period

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
   "semanticCommits": "enabled",
   "commitMessagePrefix": "chore(deps):",
   "prTitle": "chore(deps): {{{groupName}}}",
+  "minimumReleaseAge": "7 days",
   "postUpgradeTasks": {
     "commands": ["./gradlew resolveAndLockAll"],
     "fileFilters": ["**/*.lockfile"],

--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
   "semanticCommits": "enabled",
   "commitMessagePrefix": "chore(deps):",
   "prTitle": "chore(deps): {{{groupName}}}",
+  "postUpgradeTasks": {
+    "commands": ["./gradlew resolveAndLockAll"],
+    "fileFilters": ["**/*.lockfile"],
+    "executionMode": "branch"
+  },
   "packageRules": [
     {
       "description": "Group Gradle Dependencies (excluding internal packages)",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1546)

Adds postUpgradeTasks to renovate.json to run `./gradlew resolveAndLockAll` after dependency updates, ensuring all gradle.lockfile files are regenerated and committed alongside dependency changes to prevent build failures. Sets `minimumReleaseAge` to 7 days to wait for dependencies to stabilize before Renovate proposes updates, reducing the risk of adopting versions with early bugs


## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
