### PR TITLE
feat: DSTEW-1695 -adding back in mistakenly commented out step

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -41,9 +41,8 @@ jobs:
       - name: Integration test
         run: ./gradlew integrationTest
 
-# disabled until failing tests are fixed
-#      - name: Test coverage verification
-#        run: ./gradlew jacocoTestCoverageVerification
+      - name: Test coverage verification
+        run: ./gradlew jacocoTestCoverageVerification
 
       - name: Publish api models package
         run: |


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1695)
added back in code coverage check that had been mistakenly commented out 

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
