### PR TITLE
fix: pass release image tag to main deployments

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -57,8 +57,14 @@ runs:
         ECR_REGISTRY: ${{ steps.deploy_prerequisites.outputs.ecr-registry }}
         IMAGE_TAG: ${{ inputs.image-tag }}
         KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
+        APP_ENVIRONMENT: ${{ inputs.app-environment }}
         VALUES_FILE: .helm/data-access-api/values/${{ inputs.app-environment }}.yaml
       run: |
+        if [ -z "${IMAGE_TAG}" ]; then
+          echo "image-tag input is required."
+          exit 1
+        fi
+
         LAA_IPS="${{ steps.get_laa_ips.outputs.laa-ips }}"
         echo "Environment: ${APP_ENVIRONMENT}"
 

--- a/.github/actions/deploy_branch/action.yml
+++ b/.github/actions/deploy_branch/action.yml
@@ -89,6 +89,11 @@ runs:
         LAA_IPS: ${{ steps.get_laa_ips.outputs.laa-ips }}
         APP_ENVIRONMENT: ${{ inputs.app-environment }}
       run: |
+        if [ -z "${IMAGE_TAG}" ]; then
+          echo "image-tag input is required."
+          exit 1
+        fi
+
         ingress_name="$RELEASE_NAME-data-access-api"
         external_host="$RELEASE_NAME-$KUBE_NAMESPACE.cloud-platform.service.justice.gov.uk"
         internal_host="$RELEASE_NAME-internal-$KUBE_NAMESPACE.internal-non-prod.cloud-platform.service.justice.gov.uk"
@@ -96,7 +101,7 @@ runs:
         internal_identifier="$RELEASE_NAME-data-access-api-internal-$KUBE_NAMESPACE-green"
         branch_name="$BRANCH_NAME"
 
-        echo "Deploying commit: $GIT_SHA under release name: $RELEASE_NAME to $external_host and $internal_host..."
+        echo "Deploying image tag: $IMAGE_TAG under release name: $RELEASE_NAME to $external_host and $internal_host..."
 
         echo "branch name: $branch_name"
 

--- a/.github/actions/deploy_feature_branch/action.yml
+++ b/.github/actions/deploy_feature_branch/action.yml
@@ -33,6 +33,10 @@ inputs:
     description: "Comma-separated extra environment variables key=value"
     required: false
     default: ""
+  image-tag:
+    description: "Docker image tag to deploy. Defaults to the git SHA."
+    required: false
+    default: ${{ github.sha }}
 
 outputs:
   release-name:
@@ -88,7 +92,7 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr-repository }}
         ECR_REGION: ${{ inputs.ecr-region }}
         ECR_REGISTRY: ${{ steps.deploy_prerequisites.outputs.ecr-registry }}
-        GIT_SHA: ${{ github.sha }}
+        IMAGE_TAG: ${{ inputs.image-tag }}
         KUBE_NAMESPACE: ${{ inputs.kube-namespace }}
         APP_ENVIRONMENT: ${{ inputs.app-environment }}
         VALUES_FILE: .helm/data-access-api/values/${{ inputs.app-environment }}.yaml
@@ -96,6 +100,11 @@ runs:
         EXTRA_ENV: ${{ inputs.extra-env }}
       run: |
         set -euo pipefail
+
+        if [ -z "${IMAGE_TAG}" ]; then
+          echo "image-tag input is required."
+          exit 1
+        fi
 
         # Mirror Helm _helpers.tpl fullname logic:
         # if release name contains "data-access-api", fullname = release name
@@ -187,7 +196,7 @@ runs:
         helm upgrade ${RELEASE_NAME} .helm/data-access-api \
           --namespace ${KUBE_NAMESPACE} \
           --set image.repository="${ECR_REGISTRY}/${ECR_REPOSITORY}" \
-          --set image.tag="${GIT_SHA}" \
+          --set image.tag="${IMAGE_TAG}" \
           --set ingress.annotations."external-dns\.alpha\.kubernetes\.io/set-identifier"="$external_identifier" \
           --set ingress.annotations."nginx\.ingress\.kubernetes\.io/whitelist-source-range"="$LAA_IPS" \
           --set ingress.hosts="{$external_host}" \

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -96,7 +96,7 @@ jobs:
 
   deploy-uat:
     runs-on: ubuntu-latest
-    needs: [ ecr-publish-service-image, ecr-publish-mass-generator-image, vulnerability-scan-app ]
+    needs: [ release, ecr-publish-service-image, ecr-publish-mass-generator-image, vulnerability-scan-app ]
     environment: uat
     permissions:
       id-token: write
@@ -191,7 +191,7 @@ jobs:
 
   deploy-matrix-rc-feature:
     runs-on: ubuntu-latest
-    needs: [ prepare-feature-environments, release ]
+    needs: [ release, prepare-feature-environments, release ]
     environment: uat
     strategy:
       fail-fast: false
@@ -214,6 +214,7 @@ jobs:
           app-environment: rc-feature
           release-name-override: ${{ matrix.release_name }}
           extra-env: ${{ matrix.extra_env }}
+          image-tag: ${{ needs.release.outputs.published_artifact_version }}
 
   deploy-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Fix issue raised from https://github.com/ministryofjustice/laa-data-access-api/pull/363
Main pipeline missing image

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
