### PR TITLE
fix: remove concurrency check on main

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -12,10 +12,6 @@ on:
         description: "Release type"
         options: [ "patch", "minor", "major" ]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
 


### PR DESCRIPTION
## What

Remove the concurrecy check so we can still deploy older versions if pipeline is passed.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
