### PR TITLE
feat: DSTEW-1951-Update OpenApi Generate config to use springboot 4

### DIFF
--- a/data-access-api/build.gradle
+++ b/data-access-api/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.openapi.generator' version '7.13.0'
+    id 'org.openapi.generator'
     id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin'
 }
 
@@ -43,7 +43,7 @@ openApiGenerate {
             serializableModel   : "true",
             skipDefaultInterface: "true",
             useJakartaEe        : "true",
-            useSpringBoot3      : "true",
+            useSpringBoot4      : "true",
             useTags             : "true",
     ]
     globalProperties = [

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ pluginManagement {
 
     plugins {
         id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.3.0'
+        id 'org.openapi.generator' version '7.23.0'
     }
 }
 


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1951)
Switches the spring OpenAPI generator to emit Spring Boot 4-compatible stubs, aligning generated API interfaces/models with the project's Spring Boot 4.0.6 runtime

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
