### PR TITLE
feat: DSTEW-2047 include note text in event description

### DIFF
--- a/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/GetDomainEventTest.java
+++ b/data-access-service/src/integrationTest/java/uk/gov/justice/laa/dstew/access/controller/application/GetDomainEventTest.java
@@ -194,6 +194,37 @@ public class GetDomainEventTest extends BaseHarnessTest {
         Arguments.of("{\"otherField\": \"someValue\"}", null));
   }
 
+  @Test
+  public void givenNotesEvent_whenApplicationHistorySearch_thenEventDescriptionMatchesNoteText()
+      throws Exception {
+    var appId = persistedDataGenerator.createAndPersist(ApplicationEntityGenerator.class).getId();
+    String noteText = "Test note about the application";
+    String notesPayload =
+        "{\"request\": \"{\\\"notes\\\":\\\""
+            + noteText
+            + "\\\"}\", \"createdDate\": \"2026-07-24T10:00:00.000000Z\", \"applicationId\": \""
+            + appId
+            + "\"}";
+
+    persistedDataGenerator.createAndPersist(
+        DomainEventGenerator.class,
+        builder ->
+            builder
+                .applicationId(appId)
+                .caseworkerId(CaseworkerJohnDoe.getId())
+                .createdAt(DateTimeHelper.GetSystemInstanceWithoutNanoseconds())
+                .data(notesPayload)
+                .type(DomainEventType.APPLICATION_NOTES));
+
+    HarnessResult result = getUri(TestConstants.URIs.APPLICATION_HISTORY_SEARCH, appId);
+    ApplicationHistoryResponse actualResponse =
+        deserialise(result, ApplicationHistoryResponse.class);
+
+    assertOK(result);
+    assertThat(actualResponse).isNotNull();
+    assertThat(actualResponse.getEvents().getFirst().getEventDescription()).isEqualTo(noteText);
+  }
+
   @SmokeTest
   @Test
   public void givenNoUser_whenApplicationHistorySearch_thenReturnUnauthorised() throws Exception {

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/mapper/DomainEventMapper.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/mapper/DomainEventMapper.java
@@ -6,9 +6,11 @@ import org.mapstruct.Mapper;
 import uk.gov.justice.laa.dstew.access.entity.DomainEventEntity;
 import uk.gov.justice.laa.dstew.access.model.ApplicationDomainEventResponse;
 import uk.gov.justice.laa.dstew.access.model.AssignApplicationDomainEventDetails;
+import uk.gov.justice.laa.dstew.access.model.CreateApplicationNoteDomainEventDetails;
 import uk.gov.justice.laa.dstew.access.model.DomainEventDetails;
 import uk.gov.justice.laa.dstew.access.model.DomainEventType;
 import uk.gov.justice.laa.dstew.access.model.MakeDecisionDomainEventDetails;
+import uk.gov.justice.laa.dstew.access.model.NoteRequest;
 import uk.gov.justice.laa.dstew.access.model.UnassignApplicationDomainEventDetails;
 
 /** Maps between domain event entity and domain event API model. */
@@ -59,8 +61,29 @@ public interface DomainEventMapper {
           getEventDescription(data, UnassignApplicationDomainEventDetails.class);
       case APPLICATION_MAKE_DECISION_GRANTED, APPLICATION_MAKE_DECISION_REFUSED ->
           getEventDescription(data, MakeDecisionDomainEventDetails.class);
+      case APPLICATION_NOTES -> getNotesDescription(data);
       default -> null;
     };
+  }
+
+  /**
+   * Notes domain events have a nested structure, so we need to deserialize the data twice to get
+   * the note text.
+   *
+   * @param data payload of notes domain event.
+   * @return The note text in the payload.
+   */
+  private String getNotesDescription(String data) {
+    try {
+      CreateApplicationNoteDomainEventDetails details =
+          MapperUtil.getObjectMapper()
+              .readValue(data, CreateApplicationNoteDomainEventDetails.class);
+      NoteRequest noteRequest =
+          MapperUtil.getObjectMapper().readValue(details.getRequest(), NoteRequest.class);
+      return noteRequest.getNotes();
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   private static String getEventDescription(

--- a/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/model/NoteRequest.java
+++ b/data-access-service/src/main/java/uk/gov/justice/laa/dstew/access/model/NoteRequest.java
@@ -1,0 +1,17 @@
+package uk.gov.justice.laa.dstew.access.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** Represents the inner request payload of an APPLICATION_NOTES domain event. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class NoteRequest {
+  private String notes;
+}

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/mapper/DomainEventMapperTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/mapper/DomainEventMapperTest.java
@@ -6,10 +6,13 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
@@ -195,5 +198,49 @@ public class DomainEventMapperTest extends BaseMapperTest {
     ApplicationDomainEventResponse result = mapper.toDomainEvent(entity);
 
     assertThat(result.getEventDescription()).isEqualTo(expectedDescription);
+  }
+
+  @ParameterizedTest
+  @MethodSource("notesEventTypeTestCases")
+  void givenNotesEventType_whenToDomainEvent_thenEventDescriptionHandledCorrectly(
+      String notesPayload, String expectedDescription) {
+    DomainEventEntity entity =
+        DataGenerator.createDefault(
+            DomainEventGenerator.class,
+            builder -> builder.data(notesPayload).type(DomainEventType.APPLICATION_NOTES));
+
+    ApplicationDomainEventResponse result = mapper.toDomainEvent(entity);
+
+    assertThat(result.getEventDescription()).isEqualTo(expectedDescription);
+  }
+
+  private static Stream<Arguments> notesEventTypeTestCases() {
+    return Stream.of(
+        Arguments.of(
+            """
+            {"request": "{\\"notes\\":\\"Test Note\\"}", "createdDate": "2026-07-23T11:15:58.464367Z", "applicationId": "3592f19b-69bc-4d36-86bb-5a5cffc6febd"}""",
+            "Test Note"),
+        Arguments.of(
+            """
+            {"request": "{"createdDate": "2026-07-23T11:15:58.464367Z", "applicationId": "3592f19b-69bc-4d36-86bb-5a5cffc6febd"}""",
+            null));
+  }
+
+  @ParameterizedTest
+  @MethodSource("notesEventTypeNullOrBlankDataTestCases")
+  void givenNotesEventTypeWithNullOrBlankData_whenToDomainEvent_thenEventDescriptionIsNull(
+      String data) {
+    DomainEventEntity entity =
+        DataGenerator.createDefault(
+            DomainEventGenerator.class,
+            builder -> builder.data(data).type(DomainEventType.APPLICATION_NOTES));
+
+    ApplicationDomainEventResponse result = mapper.toDomainEvent(entity);
+
+    assertThat(result.getEventDescription()).isNull();
+  }
+
+  private static Stream<Arguments> notesEventTypeNullOrBlankDataTestCases() {
+    return Stream.of(Arguments.of((String) null), Arguments.of(""));
   }
 }

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/domainEvent/GetEventsTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/domainEvent/GetEventsTest.java
@@ -52,8 +52,7 @@ public class GetEventsTest extends BaseServiceTest {
 
     // then
     verify(domainEventRepository).findAll(any(Specification.class));
-    assertDomainEventsEqual(
-        orderedExpectedDomainEvents, actualDomainEvents);
+    assertDomainEventsEqual(orderedExpectedDomainEvents, actualDomainEvents);
   }
 
   @Test
@@ -173,8 +172,7 @@ public class GetEventsTest extends BaseServiceTest {
   }
 
   private void assertDomainEventsEqual(
-      List<DomainEventEntity> expected,
-      List<ApplicationDomainEventResponse> actual) {
+      List<DomainEventEntity> expected, List<ApplicationDomainEventResponse> actual) {
     assertThat(expected.size()).isEqualTo(actual.size());
     for (int i = 0; i < expected.size(); i++) {
       assertDomainEventEqual(expected.get(i), actual.get(i));

--- a/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/domainEvent/GetEventsTest.java
+++ b/data-access-service/src/test/java/uk/gov/justice/laa/dstew/access/service/domainEvent/GetEventsTest.java
@@ -52,7 +52,8 @@ public class GetEventsTest extends BaseServiceTest {
 
     // then
     verify(domainEventRepository).findAll(any(Specification.class));
-    assertDomainEventsEqual(orderedExpectedDomainEvents, actualDomainEvents);
+    assertDomainEventsEqual(
+        orderedExpectedDomainEvents, actualDomainEvents);
   }
 
   @Test
@@ -79,8 +80,101 @@ public class GetEventsTest extends BaseServiceTest {
     verify(applicationRepository, never()).findAll();
   }
 
+  @Test
+  void givenApplicationNotesWithNullRequest_whenMapEvent_thenReturnNullEventDescription() {
+    // given
+    setSecurityContext(TestConstants.Roles.CASEWORKER);
+    DomainEventEntity eventWithNullRequest =
+        DataGenerator.createDefault(DomainEventGenerator.class).toBuilder()
+            .type(DomainEventType.APPLICATION_NOTES)
+            .data(null)
+            .build();
+
+    when(domainEventRepository.findAll(any(Specification.class)))
+        .thenReturn(List.of(eventWithNullRequest));
+
+    // when
+    List<ApplicationDomainEventResponse> actualDomainEvents =
+        serviceUnderTest.getEvents(UUID.randomUUID(), List.of(DomainEventType.APPLICATION_NOTES));
+
+    // then
+    assertThat(actualDomainEvents.size()).isEqualTo(1);
+    assertThat(actualDomainEvents.get(0).getEventDescription()).isNull();
+  }
+
+  @Test
+  void givenApplicationNotesWithValidRequest_whenMapEvent_thenReturnNullEventDescription() {
+    // given
+    setSecurityContext(TestConstants.Roles.CASEWORKER);
+    String notesPayload =
+        """
+        {"request": "{\\"notes\\":\\"Test Note\\"}", "createdDate": "2026-07-23T11:15:58.464367Z", "applicationId": "3592f19b-69bc-4d36-86bb-5a5cffc6febd"}""";
+
+    DomainEventEntity eventWithNotesRequest =
+        DataGenerator.createDefault(DomainEventGenerator.class).toBuilder()
+            .type(DomainEventType.APPLICATION_NOTES)
+            .data(notesPayload)
+            .build();
+
+    when(domainEventRepository.findAll(any(Specification.class)))
+        .thenReturn(List.of(eventWithNotesRequest));
+
+    // when
+    List<ApplicationDomainEventResponse> actualDomainEvents =
+        serviceUnderTest.getEvents(UUID.randomUUID(), List.of(DomainEventType.APPLICATION_NOTES));
+
+    // then
+    assertThat(actualDomainEvents.size()).isEqualTo(1);
+    assertThat(actualDomainEvents.get(0).getEventDescription()).isEqualTo("Test Note");
+  }
+
+  @Test
+  void givenApplicationNotesWithBlankRequest_whenMapEvent_thenReturnNullEventDescription() {
+    // given
+    setSecurityContext(TestConstants.Roles.CASEWORKER);
+    DomainEventEntity eventWithBlankRequest =
+        DataGenerator.createDefault(DomainEventGenerator.class).toBuilder()
+            .type(DomainEventType.APPLICATION_NOTES)
+            .data("   ")
+            .build();
+
+    when(domainEventRepository.findAll(any(Specification.class)))
+        .thenReturn(List.of(eventWithBlankRequest));
+
+    // when
+    List<ApplicationDomainEventResponse> actualDomainEvents =
+        serviceUnderTest.getEvents(UUID.randomUUID(), List.of(DomainEventType.APPLICATION_NOTES));
+
+    // then
+    assertThat(actualDomainEvents.size()).isEqualTo(1);
+    assertThat(actualDomainEvents.get(0).getEventDescription()).isNull();
+  }
+
+  @Test
+  void givenApplicationNotesWithInvalidJson_whenMapEvent_thenReturnNullEventDescription() {
+    // given
+    setSecurityContext(TestConstants.Roles.CASEWORKER);
+    DomainEventEntity eventWithInvalidJson =
+        DataGenerator.createDefault(DomainEventGenerator.class).toBuilder()
+            .type(DomainEventType.APPLICATION_NOTES)
+            .data("invalid json data")
+            .build();
+
+    when(domainEventRepository.findAll(any(Specification.class)))
+        .thenReturn(List.of(eventWithInvalidJson));
+
+    // when
+    List<ApplicationDomainEventResponse> actualDomainEvents =
+        serviceUnderTest.getEvents(UUID.randomUUID(), List.of(DomainEventType.APPLICATION_NOTES));
+
+    // then
+    assertThat(actualDomainEvents.size()).isEqualTo(1);
+    assertThat(actualDomainEvents.getFirst().getEventDescription()).isNull();
+  }
+
   private void assertDomainEventsEqual(
-      List<DomainEventEntity> expected, List<ApplicationDomainEventResponse> actual) {
+      List<DomainEventEntity> expected,
+      List<ApplicationDomainEventResponse> actual) {
     assertThat(expected.size()).isEqualTo(actual.size());
     for (int i = 0; i < expected.size(); i++) {
       assertDomainEventEqual(expected.get(i), actual.get(i));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2047)

Parses the note text from the domain event data and returns it in the event description

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test integrationTest`
- [x] CheckStyle should not error: `./gradlew checkStyleMain`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
