### PR TITLE
fix: use real Entra ID in RC feature environments

### DIFF
--- a/.helm/data-access-api/values/rc-feature.yaml
+++ b/.helm/data-access-api/values/rc-feature.yaml
@@ -68,11 +68,11 @@ slowQueryThresholdSeconds: 1
 portForward:
   enabled: false
 
-# Mock OAuth2 Server - Use shared instance
-# All PR/feature environments share ONE mock-oauth2 instance
+# Mock OAuth2 Server - Use real Entra ID for client integrations
+# RC environments use real Azure Entra ID to support OBO flows and client testing
 mockOAuth2:
   sharedInstance:
-    enabled: true  # Use the shared instance
+    enabled: false  # Use real Entra ID from secrets
     serviceName: laa-data-access-mock-oauth2-shared
     namespace: laa-data-access-api-uat
 


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-XXX)

Disable mock-oauth2 in rc-feature.yaml to enable OBO flows and client integrations. RC environments now use real Azure Entra ID from secrets.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
