### PR TITLE
feat: DSTEW-2095 Add an independent local SNS-to-SQS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ prompts/
 ### Generated local monitoring dashboard (source of truth is the Helm template) ###
 infra/grafana/provisioning/dashboards/laa-data-access-api.json
 plans/k6-perf.md
+
+### LocalStack local state ###
+volume/

--- a/README.md
+++ b/README.md
@@ -331,6 +331,24 @@ curl -X GET "http://localhost:9000/api/v0/caseworkers" \
 
 ---
 
+### Local SNS-to-SQS seam (event-driven auto-grant)
+
+This repo owns the `data-access-events` SNS topic used by the event-driven auto-grant design
+(mirrors the deployed `laa-data-access-api-uat/resources/sns.tf`). The consumer's queue is owned
+by `laa-civil-decide-api`, so this repo's local stack also creates a private verification queue,
+purely so the producer side can be proven independently without checking out that other repo.
+
+```bash
+docker compose -f docker-compose.localstack.yml up -d
+AWS_REGION=eu-west-2 AWS_ACCESS_KEY_ID=local-access-key AWS_SECRET_ACCESS_KEY=local-secret-key \
+  AWS_ENDPOINT_URL=http://localhost:4566 scripts/localstack/smoke-test.sh
+```
+
+See `scripts/localstack/init-localstack.sh` for the full resource shape and cross-repo integration
+notes.
+
+---
+
 ### Troubleshooting Authentication
 
 **Problem: "401 Unauthorized"**

--- a/docker-compose.localstack.yml
+++ b/docker-compose.localstack.yml
@@ -1,0 +1,27 @@
+name: laa-data-access-api-localstack
+
+services:
+  localstack:
+    container_name: data-access-api-localstack
+    image: localstack/localstack:4.14.0
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sns,sqs
+      - DEBUG=1
+      - AWS_DEFAULT_REGION=${AWS_REGION:-eu-west-2}
+      - DATA_ACCESS_EVENTS_TOPIC_NAME=${DATA_ACCESS_EVENTS_TOPIC_NAME:-data-access-events}
+      - DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME=${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME:-data-access-events-producer-smoke-test-queue}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "awslocal sqs get-queue-url --queue-name ${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME:-data-access-events-producer-smoke-test-queue} > /dev/null 2>&1",
+        ]
+      interval: 5s
+      retries: 20
+      timeout: 5s
+    volumes:
+      - "./scripts/localstack/init-localstack.sh:/etc/localstack/init/ready.d/init-localstack.sh"
+      - "${LOCALSTACK_VOLUME_DIR:-./volume/localstack}:/var/lib/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"

--- a/scripts/localstack/init-localstack.sh
+++ b/scripts/localstack/init-localstack.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# LocalStack bootstrap for data-access-service-axon's producer side of the
+# event-driven auto-grant SNS-to-SQS seam.
+#
+# Idempotent: safe to run again against an already-provisioned LocalStack instance.
+set -euo pipefail
+
+: "${AWS_REGION:=eu-west-2}"
+: "${DATA_ACCESS_EVENTS_TOPIC_NAME:=data-access-events}"
+: "${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME:=data-access-events-producer-smoke-test-queue}"
+
+echo "Waiting for LocalStack SNS..."
+until awslocal sns list-topics >/dev/null 2>&1; do
+  echo "SNS is not ready yet"
+  sleep 2
+done
+
+echo "Waiting for LocalStack SQS..."
+until awslocal sqs list-queues >/dev/null 2>&1; do
+  echo "SQS is not ready yet"
+  sleep 2
+done
+
+echo "Creating SNS topic: ${DATA_ACCESS_EVENTS_TOPIC_NAME}"
+TOPIC_ARN=$(awslocal sns create-topic --name "${DATA_ACCESS_EVENTS_TOPIC_NAME}" --query 'TopicArn' --output text)
+
+echo "Creating producer-side verification queue: ${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME}"
+QUEUE_URL=$(awslocal sqs create-queue --queue-name "${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME}" --query 'QueueUrl' --output text)
+QUEUE_ARN=$(awslocal sqs get-queue-attributes --queue-url "${QUEUE_URL}" --attribute-name QueueArn --query 'Attributes.QueueArn' --output text)
+
+echo "Subscribing ${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME} to ${DATA_ACCESS_EVENTS_TOPIC_NAME} (filter: eventType=ApplicationSubmitted)"
+SUBSCRIPTION_ATTRIBUTES_FILE=$(mktemp)
+trap 'rm -f "${SUBSCRIPTION_ATTRIBUTES_FILE}"' EXIT
+cat >"${SUBSCRIPTION_ATTRIBUTES_FILE}" <<JSON
+{
+  "FilterPolicy": "{\"eventType\":[\"ApplicationSubmitted\"]}",
+  "FilterPolicyScope": "MessageBody"
+}
+JSON
+awslocal sns subscribe \
+  --topic-arn "${TOPIC_ARN}" \
+  --protocol sqs \
+  --notification-endpoint "${QUEUE_ARN}" \
+  --attributes "file://${SUBSCRIPTION_ATTRIBUTES_FILE}"
+
+echo "LocalStack producer seam ready."
+echo "  Topic ARN: ${TOPIC_ARN}"
+echo "  Verification queue URL: ${QUEUE_URL}"

--- a/scripts/localstack/smoke-test.sh
+++ b/scripts/localstack/smoke-test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Producer-side smoke test for the local SNS-to-SQS seam.
+#
+# Publishes a version 1 ApplicationSubmitted envelope (with its agreed SNS message
+# attributes) to the local data-access-events topic and verifies the private
+# verification queue (see init-localstack.sh) receives the SNS-wrapped message.
+#
+# Usage:
+#   scripts/localstack/smoke-test.sh
+set -euo pipefail
+
+: "${AWS_REGION:=eu-west-2}"
+: "${AWS_ENDPOINT_URL:=http://localhost:4566}"
+: "${DATA_ACCESS_EVENTS_TOPIC_NAME:=data-access-events}"
+: "${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME:=data-access-events-producer-smoke-test-queue}"
+
+awslocal() {
+  aws --endpoint-url "${AWS_ENDPOINT_URL}" --region "${AWS_REGION}" "$@"
+}
+
+TOPIC_ARN=$(awslocal sns list-topics --query "Topics[?ends_with(TopicArn, ':${DATA_ACCESS_EVENTS_TOPIC_NAME}')].TopicArn | [0]" --output text)
+QUEUE_URL=$(awslocal sqs get-queue-url --queue-name "${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME}" --query 'QueueUrl' --output text)
+
+if [ -z "${TOPIC_ARN}" ] || [ "${TOPIC_ARN}" = "None" ]; then
+  echo "Topic ${DATA_ACCESS_EVENTS_TOPIC_NAME} not found; run scripts/localstack/init-localstack.sh first" >&2
+  exit 1
+fi
+
+event_id="$(uuidgen 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())')"
+application_id="$(uuidgen 2>/dev/null || python3 -c 'import uuid; print(uuid.uuid4())')"
+occurred_at="$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"
+
+message_body=$(cat <<JSON
+{
+  "eventType": "ApplicationSubmitted",
+  "schemaVersion": 1,
+  "eventId": "${event_id}",
+  "occurredAt": "${occurred_at}",
+  "source": "laa-data-access-api",
+  "correlationId": "smoke-test-${event_id}",
+  "data": {
+    "applicationId": "${application_id}",
+    "applyApplicationId": "smoke-test-apply-id",
+    "laaReference": "SMOKE-TEST",
+    "applicationVersion": 1
+  }
+}
+JSON
+)
+
+echo "Publishing ApplicationSubmitted (eventId=${event_id}) to ${TOPIC_ARN}"
+awslocal sns publish \
+  --topic-arn "${TOPIC_ARN}" \
+  --message "${message_body}" \
+  --message-attributes '{"eventType":{"DataType":"String","StringValue":"ApplicationSubmitted"},"applicationType":{"DataType":"String","StringValue":"APPLY"}}' \
+  >/dev/null
+
+echo "Receiving from ${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME}..."
+received=""
+for _ in $(seq 1 10); do
+  received=$(awslocal sqs receive-message --queue-url "${QUEUE_URL}" --wait-time-seconds 1 --max-number-of-messages 10 --query 'Messages' --output json 2>/dev/null || echo "null")
+  if [ "${received}" != "null" ] && printf '%s' "${received}" | grep -q "${event_id}"; then
+    break
+  fi
+  sleep 1
+done
+
+if [ -z "${received}" ] || [ "${received}" = "null" ] || ! printf '%s' "${received}" | grep -q "${event_id}"; then
+  echo "FAILED: did not observe eventId=${event_id} on ${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME}" >&2
+  exit 1
+fi
+
+echo "PASS: SNS-wrapped ApplicationSubmitted event ${event_id} received on ${DATA_ACCESS_EVENTS_SMOKE_TEST_QUEUE_NAME}"
+
+# Clean up the message(s) we just consumed so repeated smoke-test runs stay tidy.
+receipt_handles=$(printf '%s' "${received}" | python3 -c 'import json,sys; [print(m["ReceiptHandle"]) for m in json.load(sys.stdin)]')
+while IFS= read -r handle; do
+  [ -z "${handle}" ] && continue
+  awslocal sqs delete-message --queue-url "${QUEUE_URL}" --receipt-handle "${handle}" >/dev/null
+done <<<"${receipt_handles}"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2095)

Provided a repeatable local messaging seam through which Data Access and Civil Decide can exercise the same logical SNS topic, SQS queue, subscription, DLQ, and redrive behaviour used by the deployed design. 

This supplies the highest practical integration-test boundary without duplicating the already-delivered Cloud Platform Terraform work.

Counterpart for decide: https://github.com/ministryofjustice/laa-civil-decide-api/pull/135

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
