### PR TITLE
feat: DSTEW-2093 manual-task visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ access-datastore-api/generated
 
 data-access-api/bin/
 data-access-service/bin/
+data-access-service-axon/bin/
 data-access-shared/bin/
 data-access-mass-generator/bin/
 

--- a/data-access-api/build.gradle
+++ b/data-access-api/build.gradle
@@ -40,6 +40,7 @@ openApiGenerate {
     configOptions = [
             generateBuilders    : "true",
             interfaceOnly       : "true", // This will only generate interfaces, not implementations
+            openApiNullable     : "false", // Keep nullable scalar properties as boxed Java types
             serializableModel   : "true",
             skipDefaultInterface: "true",
             useJakartaEe        : "true",

--- a/data-access-api/open-api-applications/components.yml
+++ b/data-access-api/open-api-applications/components.yml
@@ -64,6 +64,8 @@ components:
           type: boolean
         autoGrant:
           type: boolean
+          nullable: true
+          description: Null while automatic assessment is pending, false for manual work, true when automatically granted
         decisionStatus:
           $ref: "#/components/schemas/DecisionStatus"
         applicationType:
@@ -154,6 +156,8 @@ components:
           format: uuid
         autoGrant:
           type: boolean
+          nullable: true
+          description: Null while automatic assessment is pending, false for manual work, true when automatically granted
         clientFirstName:
           type: string
         clientLastName:
@@ -292,6 +296,17 @@ components:
           type: integer
           format: int64
           description: Version of application being decided, used for concurrency control
+
+    ReadyApplicationRequest:
+      type: object
+      required:
+        - applicationVersion
+      properties:
+        applicationVersion:
+          type: integer
+          format: int64
+          minimum: 0
+          description: Current Application version, used for optimistic concurrency control
 
     ApplicationProceedingsResponse:
       type: array

--- a/data-access-api/open-api-applications/resources.yml
+++ b/data-access-api/open-api-applications/resources.yml
@@ -41,7 +41,7 @@ paths:
             format: uuid
         - in: query
           name: isAutoGranted
-          description: Has the application been marked as auto granted
+          description: Filter by the recorded automatic-assessment outcome; false selects manual work and excludes null outcomes
           schema:
             type: boolean
         - in: query
@@ -328,6 +328,37 @@ paths:
         '401': { description: Unauthorized }
         '403': { description: Forbidden }
         '404': { description: Not found }
+        '500': { description: Internal server error }
+
+  /api/v0/applications/{id}/ready:
+    patch:
+      tags:
+        - application-ready-command
+      operationId: markApplicationReady
+      summary: Route a submitted Application to manual assessment
+      parameters:
+        - $ref: "../open-api-common/components.yml#/components/parameters/XServiceName"
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: './components.yml#/components/schemas/ReadyApplicationRequest'
+      responses:
+        '200': { description: Manual readiness was already recorded }
+        '204': { description: Manual readiness recorded }
+        '400': { description: Bad request }
+        '401': { description: Unauthorized }
+        '403': { description: Forbidden }
+        '404': { description: Application not found }
+        '409': { description: Stale version or incompatible auto-grant outcome }
+        '422': { description: Application is not submitted }
         '500': { description: Internal server error }
 
   /api/v0/applications/{id}/certificate:

--- a/data-access-api/open-api-specification.yml
+++ b/data-access-api/open-api-specification.yml
@@ -21,6 +21,8 @@ paths:
     $ref: "./open-api-applications/resources.yml#/paths/~1api~1v0~1applications~1{id}~1history-search"
   /api/v0/applications/{id}/decision:
     $ref: "./open-api-applications/resources.yml#/paths/~1api~1v0~1applications~1{id}~1decision"
+  /api/v0/applications/{id}/ready:
+    $ref: "./open-api-applications/resources.yml#/paths/~1api~1v0~1applications~1{id}~1ready"
   /api/v0/applications/{id}/certificate:
     $ref: "./open-api-applications/resources.yml#/paths/~1api~1v0~1applications~1{id}~1certificate"
   /api/v0/individuals:
@@ -67,6 +69,8 @@ components:
       $ref: "./open-api-common/components.yml#/components/schemas/PagingResponse"
     MakeDecisionRequest:
       $ref: "./open-api-applications/components.yml#/components/schemas/MakeDecisionRequest"
+    ReadyApplicationRequest:
+      $ref: "./open-api-applications/components.yml#/components/schemas/ReadyApplicationRequest"
     IndividualResponse:
       $ref: "./open-api-individuals/components.yml#/components/schemas/IndividualResponse"
     IndividualsResponse:

--- a/data-access-service-axon/docs/architecture.md
+++ b/data-access-service-axon/docs/architecture.md
@@ -71,12 +71,29 @@ These versions solve different problems and should not be combined:
 
 | Field | Meaning | Changes when |
 |---|---|---|
-| `applicationVersion` | Public optimistic-lock version for application changes | A decision, assignment, or unassignment succeeds |
+| `applicationVersion` | Public optimistic-lock version for application changes | A decision, manual-ready outcome, assignment, or unassignment succeeds |
 | `applicationDataVersion` | Internal pointer to an immutable `application_data` row | Sensitive/audit payload changes, including notes |
 
 Decision requests supply the expected `applicationVersion` to prevent one caller silently
 overwriting a decision based on stale state. The aggregate chooses the next
 `applicationDataVersion`; callers never manage this internal storage detail.
+
+## Automatic-assessment outcome and manual visibility
+
+`autoGrant` is a tri-state outcome independent of Application Status:
+
+- `null` means automatic assessment has not recorded an outcome, so the submitted Application is
+  excluded from manual-task queries;
+- `false` means assessment completed without an automatic grant, so the Application can be
+  selected with `isAutoGranted=false` for manual work;
+- `true` means an automatically granted Decision was recorded, so the Application remains outside
+  manual work.
+
+`PATCH /api/v0/applications/{id}/ready` records the false outcome without changing
+`APPLICATION_SUBMITTED`. The aggregate appends a new immutable `application_data` version and then
+emits `ApplicationReadyForManualAssessmentEvent`, which carries only the Application identifier,
+public and data versions, and occurrence time. Replaying the event restores the aggregate outcome
+and advances the disposable projection to the same immutable data version.
 
 ## Transaction and processing choices
 

--- a/data-access-service-axon/docs/example-payloads.md
+++ b/data-access-service-axon/docs/example-payloads.md
@@ -150,6 +150,94 @@ Note: `proceedingType`, `categoryOfLaw`, and `matterType` on the response are cu
 populated from fields the read-model mapper projects; supplying them in `applicationContent`
 does not yet surface them here.
 
+### Exercise manual-task visibility
+
+This sequence exercises the DSTEW-2093 contract end to end: a submitted Application starts with
+`autoGrant=null`, is absent from the manual-task query, and becomes visible only after the ready
+operation records `autoGrant=false`. It uses fresh identifiers so the sequence can be repeated.
+
+Create a submitted Application:
+
+```bash
+APP_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+PROCEEDING_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+
+curl -i -X POST http://localhost:8082/api/v0/applications \
+  -H "Content-Type: application/json" \
+  -H "X-Service-Name: CIVIL_APPLY" \
+  -H "X-Schema-Version: 1" \
+  --data-binary @- <<JSON
+{
+  "applicationType": "INITIAL",
+  "status": "APPLICATION_SUBMITTED",
+  "laaReference": "LAA-MANUAL-READY",
+  "applicationContent": {
+    "id": "$APP_ID",
+    "submittedAt": "2026-08-03T12:00:00Z",
+    "status": "APPLICATION_SUBMITTED",
+    "laaReference": "LAA-MANUAL-READY",
+    "proceedings": [
+      {
+        "id": "$PROCEEDING_ID",
+        "leadProceeding": true,
+        "description": "Manual readiness test",
+        "categoryOfLaw": "FAMILY",
+        "matterType": "SPECIAL_CHILDREN_ACT"
+      }
+    ]
+  },
+  "individuals": [
+    {
+      "firstName": "Manual",
+      "lastName": "Readiness",
+      "dateOfBirth": "1990-04-12",
+      "type": "CLIENT",
+      "details": {
+        "nationalInsuranceNumber": "AB123456C"
+      }
+    }
+  ]
+}
+JSON
+```
+
+Confirm it is not yet a manual task. The selected result should be an empty array because the
+Application has `autoGrant=null`:
+
+```bash
+curl -s "http://localhost:8082/api/v0/applications?status=APPLICATION_SUBMITTED&isAutoGranted=false&page=1&pageSize=20" \
+  | jq --arg id "$APP_ID" '.applications | map(select(.applicationId == $id))'
+```
+
+Record manual readiness using the current Application version (`0` immediately after creation):
+
+```bash
+curl -i -X PATCH "http://localhost:8082/api/v0/applications/$APP_ID/ready" \
+  -H "Content-Type: application/json" \
+  -H "X-Service-Name: CIVIL_DECIDE" \
+  -d '{"applicationVersion":0}'
+```
+
+The first call returns `204 No Content`. Repeating the same call is idempotent and returns
+`200 OK` without appending another event. A submitted Application that is still undecided returns
+`409 Conflict` for a genuinely stale version; an in-progress Application returns
+`422 Unprocessable Content`.
+
+Confirm the outcome and incremented version through direct lookup:
+
+```bash
+curl -s "http://localhost:8082/api/v0/applications/$APP_ID" \
+  | jq '{applicationId, status, autoGrant, version}'
+```
+
+Expected fields are `status: "APPLICATION_SUBMITTED"`, `autoGrant: false`, and `version: 1`.
+The same Application should now appear in the manual-task query:
+
+```bash
+curl -s "http://localhost:8082/api/v0/applications?status=APPLICATION_SUBMITTED&isAutoGranted=false&page=1&pageSize=20" \
+  | jq --arg id "$APP_ID" '.applications | map(select(.applicationId == $id))'
+```
+
 ### Get the application certificate
 
 `GET /api/v0/applications/{id}/certificate`

--- a/data-access-service-axon/docs/projections-and-replay.md
+++ b/data-access-service-axon/docs/projections-and-replay.md
@@ -22,6 +22,12 @@ router and initializer are described in [Linked applications](linked-application
 `ApplicationProjection` stores thin, searchable control state and the current
 `applicationDataVersion`. Query handlers hydrate detailed fields from `application_data`.
 
+Decision and manual-ready events both advance the public and data versions. A replay of
+`ApplicationReadyForManualAssessmentEvent` therefore restores the pointer to the immutable payload
+containing `autoGrant=false`; no command handler or external side effect is invoked during replay.
+List queries can filter that hydrated value with `isAutoGranted=false`, which deliberately excludes
+null outcomes, while identifier lookup remains unfiltered.
+
 For a single application, a missing referenced payload means no hydrated application is returned.
 For list queries, payloads are batch-loaded to avoid one lookup per row. Linked-group rows are also
 batch-loaded for the result page.

--- a/data-access-service-axon/docs/worked-example-decision.md
+++ b/data-access-service-axon/docs/worked-example-decision.md
@@ -140,3 +140,25 @@ Related tests cover:
 - serialized event payloads not containing the sensitive decision request.
 
 Use [Testing Axon code](testing-axon-code.md) to decide where a new scenario belongs.
+
+## Related example: routing to manual assessment
+
+`PATCH /api/v0/applications/{id}/ready` follows the same thin-event and immutable-data pattern but
+does not create a Decision. `ReadyApplicationCommandMapper` maps the current public Application
+version into `MarkApplicationReadyCommand`. The aggregate reconstructs the current Status and
+`autoGrant` outcome from its stream, then returns one of these outcomes:
+
+| Existing state | Result |
+|---|---|
+| `APPLICATION_SUBMITTED`, `autoGrant=null`, current version | Append `autoGrant=false`, emit `ApplicationReadyForManualAssessmentEvent`, return `204` |
+| `autoGrant=false` | Idempotent success with no data append or event, return `200` |
+| `autoGrant=true` | Reject the incompatible outcome with `409` |
+| Pending outcome but stale version | Reject with `409` |
+| Status other than `APPLICATION_SUBMITTED` | Reject with `422` |
+
+The ready event contains only `applicationId`, `applicationVersion`, `applicationDataVersion`, and
+`occurredAt`. `ApplicationProjection` advances its version pointer when handling or replaying that
+event. Hydration then reads `autoGrant=false` from the referenced payload, allowing
+`GET /api/v0/applications?status=APPLICATION_SUBMITTED&isAutoGranted=false` to return only work
+explicitly routed to a caseworker. Direct lookup by identifier continues to return a submitted
+Application while its outcome is still null.

--- a/data-access-service-axon/src/integrationTest/java/uk/gov/justice/laa/dstew/access/PostgresAxonIntegrationTest.java
+++ b/data-access-service-axon/src/integrationTest/java/uk/gov/justice/laa/dstew/access/PostgresAxonIntegrationTest.java
@@ -62,6 +62,7 @@ import uk.gov.justice.laa.dstew.access.model.MeritsDecisionDetailsRequest;
 import uk.gov.justice.laa.dstew.access.model.MeritsDecisionStatus;
 import uk.gov.justice.laa.dstew.access.model.OpponentResponse;
 import uk.gov.justice.laa.dstew.access.model.ProviderResponse;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
 import uk.gov.justice.laa.dstew.access.model.ScopeLimitationResponse;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadRepository;
@@ -438,6 +439,49 @@ class PostgresAxonIntegrationTest {
                 Integer.class,
                 applicationId))
         .isEqualTo(2);
+  }
+
+  @Test
+  void givenSubmittedApplication_whenMarkedReady_thenPersistsFalseOutcomeAndThinEvent()
+      throws Exception {
+    UUID applicationId = UUID.randomUUID();
+    applicationId(post(validCreateApplicationRequest(applicationId, UUID.randomUUID()), headers()));
+    awaitProjection(applicationId);
+    ReadyApplicationRequest request =
+        ReadyApplicationRequest.builder().applicationVersion(0L).build();
+
+    ResponseEntity<Void> response =
+        restTemplate.exchange(
+            "http://localhost:" + port + "/api/v0/applications/" + applicationId + "/ready",
+            HttpMethod.PATCH,
+            new HttpEntity<>(request, headers()),
+            Void.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    ApplicationReadModel ready = awaitProjectionVersion(applicationId, 1L);
+    assertThat(ready.getStatus()).isEqualTo("APPLICATION_SUBMITTED");
+    assertThat(ready.getAutoGranted()).isFalse();
+    assertThat(
+            jdbcTemplate.queryForObject(
+                "SELECT payload ->> 'autoGranted' FROM axon.application_data "
+                    + "WHERE application_id = ? AND version = 1",
+                String.class,
+                applicationId))
+        .isEqualTo("false");
+    assertThat(
+            jdbcTemplate.queryForMap(
+                "SELECT payload_type, convert_from(payload, 'UTF8') AS payload "
+                    + "FROM axon.domain_event_entry "
+                    + "WHERE aggregate_identifier = ? AND sequence_number = 1",
+                applicationId.toString()))
+        .satisfies(
+            event -> {
+              assertThat(event.get("payload_type").toString())
+                  .endsWith("ApplicationReadyForManualAssessmentEvent");
+              assertThat(event.get("payload").toString())
+                  .contains("applicationDataVersion")
+                  .doesNotContain("applicationContent", "LAA-123");
+            });
   }
 
   @Test

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationAggregate.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationAggregate.java
@@ -22,6 +22,9 @@ import uk.gov.justice.laa.dstew.access.command.application.linkedgroup.LinkedApp
 import uk.gov.justice.laa.dstew.access.command.application.linkedgroup.ValidateApplicationExistsCommand;
 import uk.gov.justice.laa.dstew.access.command.application.note.CreateNoteCommand;
 import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.MarkApplicationReadyCommand;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ReadyApplicationResult;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 
 /** Event-sourced consistency boundary for an Application and its owned child state. */
@@ -204,6 +207,33 @@ public class ApplicationAggregate {
     eventAppender.append(event);
   }
 
+  /** Stores {@code autoGrant=false} as the next immutable Application-data version. */
+  @CommandHandler
+  ReadyApplicationResult handle(
+      MarkApplicationReadyCommand command,
+      ApplicationDataStore applicationDataStore,
+      EventAppender eventAppender) {
+    requireApplicationExists(command.applicationId());
+    ReadyApplicationResult result = ApplicationDecider.decideReady(state, command);
+    if (result == ReadyApplicationResult.ALREADY_RECORDED) {
+      return result;
+    }
+
+    var current = applicationDataStore.get(applicationId, state.applicationDataVersion);
+    long nextApplicationVersion = state.applicationVersion + 1;
+    long nextDataVersion = state.applicationDataVersion + 1;
+    applicationDataStore.append(
+        applicationId,
+        nextDataVersion,
+        current.withManualAssessmentRequired(),
+        command.serialisedRequest(),
+        command.occurredAt());
+    eventAppender.append(
+        new ApplicationReadyForManualAssessmentEvent(
+            applicationId, nextApplicationVersion, nextDataVersion, command.occurredAt()));
+    return result;
+  }
+
   private void requireApplicationExists(UUID requestedApplicationId) {
     if (applicationId == null) {
       throw new ResourceNotFoundException(
@@ -239,6 +269,11 @@ public class ApplicationAggregate {
 
   @EventSourcingHandler
   void on(NoteCreatedEvent event) {
+    ApplicationEvolve.apply(state, event);
+  }
+
+  @EventSourcingHandler
+  void on(ApplicationReadyForManualAssessmentEvent event) {
     ApplicationEvolve.apply(state, event);
   }
 

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationDecider.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationDecider.java
@@ -22,9 +22,13 @@ import uk.gov.justice.laa.dstew.access.command.application.decision.MakeDecision
 import uk.gov.justice.laa.dstew.access.command.application.linkedgroup.LinkedApplicationGroupRequested;
 import uk.gov.justice.laa.dstew.access.command.application.note.CreateNoteCommand;
 import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.MarkApplicationReadyCommand;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ReadyApplicationResult;
+import uk.gov.justice.laa.dstew.access.exception.ApplicationAutoGrantOutcomeConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationCreationConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationGroupInvariantException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationVersionConflictException;
+import uk.gov.justice.laa.dstew.access.exception.InvalidApplicationStateException;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
 
@@ -150,6 +154,25 @@ public final class ApplicationDecider {
   public static NoteCreatedEvent decideNote(ApplicationState state, CreateNoteCommand command) {
     return new NoteCreatedEvent(
         state.applicationId, state.applicationDataVersion + 1, command.occurredAt());
+  }
+
+  /** Validates an idempotent transition to manual-assessment readiness. */
+  public static ReadyApplicationResult decideReady(
+      ApplicationState state, MarkApplicationReadyCommand command) {
+    if (Boolean.FALSE.equals(state.autoGranted)) {
+      return ReadyApplicationResult.ALREADY_RECORDED;
+    }
+    if (Boolean.TRUE.equals(state.autoGranted)) {
+      throw new ApplicationAutoGrantOutcomeConflictException(command.applicationId());
+    }
+    if (!"APPLICATION_SUBMITTED".equals(state.status)) {
+      throw new InvalidApplicationStateException(command.applicationId(), state.status);
+    }
+    if (command.expectedApplicationVersion() != state.applicationVersion) {
+      throw new ApplicationVersionConflictException(
+          command.applicationId(), command.expectedApplicationVersion());
+    }
+    return ReadyApplicationResult.RECORDED;
   }
 
   private static void validateDecision(MakeApplicationDecisionCommand command) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationEvolve.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationEvolve.java
@@ -7,6 +7,7 @@ import uk.gov.justice.laa.dstew.access.command.application.assignment.Applicatio
 import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
 import uk.gov.justice.laa.dstew.access.command.application.linkedgroup.LinkedApplicationGroupRequested;
 import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
 
 /** Event-fold functions for {@link ApplicationState}. */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,6 +19,8 @@ public final class ApplicationEvolve {
     state.isAssociatedMember = event.leadApplicationId() != null;
     state.schemaVersion = event.schemaVersion();
     state.requestFingerprint = event.requestFingerprint();
+    state.status = event.status();
+    state.autoGranted = null;
     state.applicationDataVersion = event.applicationDataVersion();
     state.applicationVersion = 0L;
   }
@@ -26,6 +29,14 @@ public final class ApplicationEvolve {
   public static void apply(ApplicationState state, ApplicationDecisionMadeEvent event) {
     state.applicationVersion = event.applicationVersion();
     state.applicationDataVersion = event.applicationDataVersion();
+    state.autoGranted = event.autoGranted();
+  }
+
+  /** Applies an {@link ApplicationReadyForManualAssessmentEvent} to the given state. */
+  public static void apply(ApplicationState state, ApplicationReadyForManualAssessmentEvent event) {
+    state.applicationVersion = event.applicationVersion();
+    state.applicationDataVersion = event.applicationDataVersion();
+    state.autoGranted = false;
   }
 
   /** Applies an {@link ApplicationAssignedToCaseworkerEvent} to the given state. */

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationState.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationState.java
@@ -14,6 +14,8 @@ public class ApplicationState {
   boolean isAssociatedMember;
   int schemaVersion;
   String requestFingerprint;
+  String status;
+  Boolean autoGranted;
   long applicationDataVersion;
   long applicationVersion;
   UUID caseworkerId;

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/data/ApplicationDataPayload.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/data/ApplicationDataPayload.java
@@ -126,6 +126,30 @@ public record ApplicationDataPayload(
         notes);
   }
 
+  /** Returns a complete new data version marked as requiring manual assessment. */
+  public ApplicationDataPayload withManualAssessmentRequired() {
+    return new ApplicationDataPayload(
+        laaReference,
+        applicationContent,
+        individuals,
+        applyApplicationId,
+        submittedAt,
+        officeCode,
+        usedDelegatedFunctions,
+        categoryOfLaw,
+        matterType,
+        proceedings,
+        serialisedRequest,
+        overallDecision,
+        false,
+        meritsDecisions,
+        certificate,
+        decisionSerialisedRequest,
+        decisionEventDescription,
+        assignmentEventDescription,
+        notes);
+  }
+
   /** Returns a complete new data version with the given note appended. */
   public ApplicationDataPayload withNote(String noteText, Instant createdAt) {
     List<ApplicationNote> updated = new ArrayList<>(notes);

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ready/ApplicationReadyForManualAssessmentEvent.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ready/ApplicationReadyForManualAssessmentEvent.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.laa.dstew.access.command.application.ready;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.axonframework.eventsourcing.annotation.EventTag;
+import org.axonframework.messaging.eventhandling.annotation.Event;
+
+/** Thin event recording the immutable data version that contains {@code autoGrant=false}. */
+@Event
+public record ApplicationReadyForManualAssessmentEvent(
+    @EventTag(key = "ApplicationAggregate") UUID applicationId,
+    long applicationVersion,
+    long applicationDataVersion,
+    Instant occurredAt) {}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ready/MarkApplicationReadyCommand.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ready/MarkApplicationReadyCommand.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.laa.dstew.access.command.application.ready;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.axonframework.messaging.commandhandling.annotation.Command;
+import org.axonframework.modelling.annotation.TargetEntityId;
+
+/** Records that automatic assessment completed without an automatic grant. */
+@Command(routingKey = "applicationId")
+public record MarkApplicationReadyCommand(
+    @TargetEntityId UUID applicationId,
+    long expectedApplicationVersion,
+    String serialisedRequest,
+    Instant occurredAt) {}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ready/ReadyApplicationResult.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ready/ReadyApplicationResult.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.laa.dstew.access.command.application.ready;
+
+/** Outcome of idempotently recording manual-assessment readiness. */
+public enum ReadyApplicationResult {
+  RECORDED,
+  ALREADY_RECORDED
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/ApplicationExceptionHandler.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/ApplicationExceptionHandler.java
@@ -7,9 +7,11 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import uk.gov.justice.laa.dstew.access.exception.ApplicationAutoGrantOutcomeConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationCreationConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationGroupInvariantException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationVersionConflictException;
+import uk.gov.justice.laa.dstew.access.exception.InvalidApplicationStateException;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
 
@@ -73,6 +75,24 @@ public class ApplicationExceptionHandler {
       ApplicationVersionConflictException exception) {
     return ResponseEntity.status(HttpStatus.CONFLICT)
         .body(ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, exception.getMessage()));
+  }
+
+  /** Returns a conflict when manual readiness would overwrite an automatic grant. */
+  @ExceptionHandler(ApplicationAutoGrantOutcomeConflictException.class)
+  ResponseEntity<ProblemDetail> handleApplicationAutoGrantOutcomeConflictException(
+      ApplicationAutoGrantOutcomeConflictException exception) {
+    return ResponseEntity.status(HttpStatus.CONFLICT)
+        .body(ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT, exception.getMessage()));
+  }
+
+  /** Returns an unprocessable response when manual readiness is invalid for the lifecycle state. */
+  @ExceptionHandler(InvalidApplicationStateException.class)
+  ResponseEntity<ProblemDetail> handleInvalidApplicationStateException(
+      InvalidApplicationStateException exception) {
+    return ResponseEntity.status(HttpStatus.UNPROCESSABLE_CONTENT)
+        .body(
+            ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_CONTENT, exception.getMessage()));
   }
 
   private ResponseEntity<ProblemDetail> validationError(List<String> errors) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandController.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandController.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import java.net.URI;
 import java.sql.SQLException;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
 import org.axonframework.modelling.ConcurrencyException;
@@ -20,11 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationCommand;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerService;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ReadyApplicationResult;
 import uk.gov.justice.laa.dstew.access.model.ApplicationCreateRequest;
 import uk.gov.justice.laa.dstew.access.model.CaseworkerAssignRequest;
 import uk.gov.justice.laa.dstew.access.model.CaseworkerUnassignRequest;
 import uk.gov.justice.laa.dstew.access.model.CreateNoteRequest;
 import uk.gov.justice.laa.dstew.access.model.MakeDecisionRequest;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
 import uk.gov.justice.laa.dstew.access.model.ServiceName;
 import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
@@ -43,6 +46,7 @@ public class ApplicationCommandController {
   private final AssignCaseworkerRequestMapper assignCaseworkerRequestMapper;
   private final UnassignCaseworkerRequestMapper unassignCaseworkerRequestMapper;
   private final CreateNoteCommandMapper createNoteCommandMapper;
+  private final ReadyApplicationCommandMapper readyApplicationCommandMapper;
 
   /** Creates the command adapter. */
   public ApplicationCommandController(
@@ -53,7 +57,8 @@ public class ApplicationCommandController {
       AssignCaseworkerService assignCaseworkerService,
       AssignCaseworkerRequestMapper assignCaseworkerRequestMapper,
       UnassignCaseworkerRequestMapper unassignCaseworkerRequestMapper,
-      CreateNoteCommandMapper createNoteCommandMapper) {
+      CreateNoteCommandMapper createNoteCommandMapper,
+      ReadyApplicationCommandMapper readyApplicationCommandMapper) {
     this.commandGateway = commandGateway;
     this.projectionGateway = projectionGateway;
     this.commandMapper = commandMapper;
@@ -62,6 +67,7 @@ public class ApplicationCommandController {
     this.assignCaseworkerRequestMapper = assignCaseworkerRequestMapper;
     this.unassignCaseworkerRequestMapper = unassignCaseworkerRequestMapper;
     this.createNoteCommandMapper = createNoteCommandMapper;
+    this.readyApplicationCommandMapper = readyApplicationCommandMapper;
   }
 
   /** Assigns a caseworker to one or more Applications after validating the complete batch. */
@@ -96,6 +102,20 @@ public class ApplicationCommandController {
       @Valid @RequestBody MakeDecisionRequest request) {
     dispatchWithRetry(decisionCommandMapper.toCommand(id, request));
     return ResponseEntity.noContent().build();
+  }
+
+  /** Records that a submitted Application is ready for manual assessment. */
+  @PatchMapping("/{id}/ready")
+  public ResponseEntity<Void> markApplicationReady(
+      @RequestHeader("X-Service-Name") ServiceName serviceName,
+      @PathVariable UUID id,
+      @Valid @RequestBody ReadyApplicationRequest request) {
+    ReadyApplicationResult result =
+        dispatchWithRetry(
+            readyApplicationCommandMapper.toCommand(id, request), ReadyApplicationResult.class);
+    return result == ReadyApplicationResult.RECORDED
+        ? ResponseEntity.noContent().build()
+        : ResponseEntity.ok().build();
   }
 
   /** Appends a note to an existing Application. */
@@ -135,14 +155,22 @@ public class ApplicationCommandController {
   }
 
   void dispatchWithRetry(Object command) {
+    dispatchWithRetry(() -> commandGateway.sendAndWait(command));
+  }
+
+  private <R> R dispatchWithRetry(Object command, Class<R> responseType) {
+    return dispatchWithRetry(() -> commandGateway.sendAndWait(command, responseType));
+  }
+
+  private <R> R dispatchWithRetry(Supplier<R> dispatch) {
     try {
-      commandGateway.sendAndWait(command);
+      return dispatch.get();
     } catch (RuntimeException first) {
       if (!isRetryableConcurrentWrite(first)) {
         throw first;
       }
       try {
-        commandGateway.sendAndWait(command);
+        return dispatch.get();
       } catch (RuntimeException retry) {
         retry.addSuppressed(first);
         throw retry;

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationQueryController.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationQueryController.java
@@ -26,6 +26,7 @@ import uk.gov.justice.laa.dstew.access.model.ApplicationSummaryResponse;
 import uk.gov.justice.laa.dstew.access.model.DomainEventType;
 import uk.gov.justice.laa.dstew.access.model.MatterType;
 import uk.gov.justice.laa.dstew.access.model.ServiceName;
+import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationNotesResult;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.FindAllApplicationsQuery;
@@ -45,6 +46,7 @@ public class ApplicationQueryController {
   private final GetAllApplicationsResponseMapper getAllResponseMapper;
   private final GetApplicationHistoryResponseMapper historyResponseMapper;
   private final GetAllNotesForApplicationResponseMapper notesResponseMapper;
+  private final SubscriptionProjectionGateway projectionGateway;
 
   /**
    * Constructs the controller with its query gateway and response mappers.
@@ -66,21 +68,24 @@ public class ApplicationQueryController {
       GetApplicationResponseMapper responseMapper,
       GetAllApplicationsResponseMapper getAllResponseMapper,
       GetApplicationHistoryResponseMapper historyResponseMapper,
-      GetAllNotesForApplicationResponseMapper notesResponseMapper) {
+      GetAllNotesForApplicationResponseMapper notesResponseMapper,
+      SubscriptionProjectionGateway projectionGateway) {
     this.queryGateway = queryGateway;
     this.responseMapper = responseMapper;
     this.getAllResponseMapper = getAllResponseMapper;
     this.historyResponseMapper = historyResponseMapper;
     this.notesResponseMapper = notesResponseMapper;
+    this.projectionGateway = projectionGateway;
   }
 
   /**
    * Returns a paginated, filtered list of Application summaries.
    *
-   * <p>Filters on {@code status}, {@code laaReference}, and {@code matterType} are applied. {@code
-   * clientFirstName}, {@code clientLastName}, {@code clientDateOfBirth}, and {@code userId} are
-   * accepted for API compatibility but not yet used as filters — a future migration will
-   * denormalise client fields from the {@code individuals} JSON column to enable them.
+   * <p>Filters on {@code status}, {@code laaReference}, {@code matterType}, and {@code
+   * isAutoGranted} are applied. {@code clientFirstName}, {@code clientLastName}, {@code
+   * clientDateOfBirth}, and {@code userId} are accepted for API compatibility but not yet used as
+   * filters — a future migration will denormalise client fields from the {@code individuals} JSON
+   * column to enable them.
    */
   @GetMapping
   public ResponseEntity<ApplicationSummaryResponse> getApplications(
@@ -90,6 +95,7 @@ public class ApplicationQueryController {
       @RequestParam(required = false) String clientLastName,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate clientDateOfBirth,
+      @RequestParam(required = false) Boolean isAutoGranted,
       @RequestParam(required = false) MatterType matterType,
       @RequestParam(required = false) ApplicationSortBy sortBy,
       @RequestParam(required = false) ApplicationOrderBy orderBy,
@@ -105,6 +111,7 @@ public class ApplicationQueryController {
                     clientFirstName,
                     clientLastName,
                     clientDateOfBirth,
+                    isAutoGranted,
                     sortBy == null ? null : sortBy.name(),
                     orderBy == null ? null : orderBy.name(),
                     page,
@@ -118,7 +125,7 @@ public class ApplicationQueryController {
   @GetMapping("/{id}")
   public ResponseEntity<ApplicationResponse> getApplicationById(@PathVariable UUID id) {
     ApplicationReadModel application =
-        findApplication(id)
+        findApplicationAwaitingProjection(id)
             .orElseThrow(
                 () -> new ResourceNotFoundException("No application found with ID: " + id));
     return ResponseEntity.ok(responseMapper.toResponse(application));
@@ -169,6 +176,11 @@ public class ApplicationQueryController {
             .orElseThrow(
                 () -> new ResourceNotFoundException("No application found with ID: " + id));
     return ResponseEntity.ok(response);
+  }
+
+  private Optional<ApplicationReadModel> findApplicationAwaitingProjection(UUID applicationId) {
+    return projectionGateway.findProjection(
+        new FindApplicationByIdQuery(applicationId), ApplicationReadModel.class);
   }
 
   private Optional<ApplicationReadModel> findApplication(UUID applicationId) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/GetAllApplicationsResponseMapper.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/GetAllApplicationsResponseMapper.java
@@ -60,6 +60,7 @@ public class GetAllApplicationsResponseMapper {
     summary.setApplicationType(ApplicationType.INITIAL);
     summary.setIsLead(app.getLeadApplicationId() == null);
     summary.setAssignedTo(app.getCaseworkerId());
+    summary.setAutoGrant(app.getAutoGranted());
 
     ApplicationIndividual client = primaryClient(app);
     if (client != null) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ReadyApplicationCommandMapper.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ReadyApplicationCommandMapper.java
@@ -1,0 +1,35 @@
+package uk.gov.justice.laa.dstew.access.controller.application;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Component;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectMapper;
+import uk.gov.justice.laa.dstew.access.command.application.ready.MarkApplicationReadyCommand;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
+
+/** Maps the manual-readiness HTTP contract to its Axon command. */
+@Component
+public class ReadyApplicationCommandMapper {
+
+  private final ObjectMapper objectMapper;
+
+  public ReadyApplicationCommandMapper(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  /** Maps a request for the supplied Application identifier. */
+  public MarkApplicationReadyCommand toCommand(
+      UUID applicationId, ReadyApplicationRequest request) {
+    return new MarkApplicationReadyCommand(
+        applicationId, request.getApplicationVersion(), serialise(request), Instant.now());
+  }
+
+  private String serialise(ReadyApplicationRequest request) {
+    try {
+      return objectMapper.writeValueAsString(request);
+    } catch (JacksonException exception) {
+      throw new IllegalStateException("Unable to serialise ReadyApplicationRequest", exception);
+    }
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/exception/ApplicationAutoGrantOutcomeConflictException.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/exception/ApplicationAutoGrantOutcomeConflictException.java
@@ -1,0 +1,11 @@
+package uk.gov.justice.laa.dstew.access.exception;
+
+import java.util.UUID;
+
+/** Raised when manual readiness would overwrite an existing automatic-grant outcome. */
+public class ApplicationAutoGrantOutcomeConflictException extends RuntimeException {
+
+  public ApplicationAutoGrantOutcomeConflictException(UUID applicationId) {
+    super("Application " + applicationId + " already has an incompatible auto-grant outcome");
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/exception/InvalidApplicationStateException.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/exception/InvalidApplicationStateException.java
@@ -1,0 +1,11 @@
+package uk.gov.justice.laa.dstew.access.exception;
+
+import java.util.UUID;
+
+/** Raised when an operation is not valid for the Application's lifecycle state. */
+public class InvalidApplicationStateException extends RuntimeException {
+
+  public InvalidApplicationStateException(UUID applicationId, String status) {
+    super("Application " + applicationId + " cannot be made ready from status " + status);
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/SubscriptionProjectionGateway.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/SubscriptionProjectionGateway.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.dstew.access.query;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.springframework.beans.factory.annotation.Value;
@@ -52,6 +53,20 @@ public class SubscriptionProjectionGateway {
     }
   }
 
+  /** Waits for an existing projection to become readable, including the first delayed update. */
+  public <R> Optional<R> findProjection(Object query, Class<R> projectionType) {
+    CompletableFuture<R> firstResult =
+        Mono.from(queryGateway.subscriptionQuery(query, projectionType)).toFuture();
+    try {
+      if (!doAwait(firstResult)) {
+        return Optional.empty();
+      }
+      return Optional.ofNullable(queryGateway.query(query, projectionType).join());
+    } finally {
+      firstResult.cancel(true);
+    }
+  }
+
   private <R> boolean doAwait(CompletableFuture<R> firstResult) {
     try {
       Boolean result =
@@ -61,10 +76,14 @@ public class SubscriptionProjectionGateway {
               .block();
       return Boolean.TRUE.equals(result);
     } catch (RuntimeException e) {
-      if (e.getCause() instanceof InterruptedException) {
-        Thread.currentThread().interrupt();
-      }
+      restoreInterrupt(e);
       throw e;
+    }
+  }
+
+  private void restoreInterrupt(RuntimeException exception) {
+    if (exception.getCause() instanceof InterruptedException) {
+      Thread.currentThread().interrupt();
     }
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
@@ -24,6 +24,7 @@ import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataS
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationNote;
 import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
 import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadRepository;
 
@@ -148,19 +149,24 @@ public class ApplicationProjection {
   /** Advances the current-state row to the immutable data version containing the decision. */
   @EventHandler
   public void on(ApplicationDecisionMadeEvent event, QueryUpdateEmitter queryUpdateEmitter) {
-    applicationReadRepository
-        .findById(event.applicationId())
-        .ifPresent(
-            application -> {
-              application.setApplicationDataVersion(event.applicationDataVersion());
-              application.setApplicationVersion(event.applicationVersion());
-              application.setModifiedAt(event.occurredAt());
-              ApplicationReadModel saved = applicationReadRepository.save(application);
-              queryUpdateEmitter.emit(
-                  FindApplicationByIdQuery.class,
-                  query -> query.applicationId().equals(event.applicationId()),
-                  saved);
-            });
+    advanceCurrentState(
+        event.applicationId(),
+        event.applicationVersion(),
+        event.applicationDataVersion(),
+        event.occurredAt(),
+        queryUpdateEmitter);
+  }
+
+  /** Advances the current-state row to the immutable data version containing manual readiness. */
+  @EventHandler
+  public void on(
+      ApplicationReadyForManualAssessmentEvent event, QueryUpdateEmitter queryUpdateEmitter) {
+    advanceCurrentState(
+        event.applicationId(),
+        event.applicationVersion(),
+        event.applicationDataVersion(),
+        event.occurredAt(),
+        queryUpdateEmitter);
   }
 
   /** Updates the assigned caseworker and referenced application-data version. */
@@ -206,6 +212,27 @@ public class ApplicationProjection {
             });
   }
 
+  private void advanceCurrentState(
+      UUID applicationId,
+      long applicationVersion,
+      long applicationDataVersion,
+      java.time.Instant occurredAt,
+      QueryUpdateEmitter queryUpdateEmitter) {
+    applicationReadRepository
+        .findById(applicationId)
+        .ifPresent(
+            application -> {
+              application.setApplicationDataVersion(applicationDataVersion);
+              application.setApplicationVersion(applicationVersion);
+              application.setModifiedAt(occurredAt);
+              ApplicationReadModel saved = applicationReadRepository.save(application);
+              queryUpdateEmitter.emit(
+                  FindApplicationByIdQuery.class,
+                  query -> query.applicationId().equals(applicationId),
+                  saved);
+            });
+  }
+
   /** Clears the disposable current-state table before replay. */
   @ResetHandler
   public void reset() {
@@ -217,7 +244,9 @@ public class ApplicationProjection {
         && (query.laaReference() == null
             || Objects.equals(application.getLaaReference(), query.laaReference()))
         && (query.matterType() == null
-            || Objects.equals(application.getMatterType(), query.matterType()));
+            || Objects.equals(application.getMatterType(), query.matterType()))
+        && (query.isAutoGranted() == null
+            || Objects.equals(application.getAutoGranted(), query.isAutoGranted()));
   }
 
   private Comparator<ApplicationReadModel> comparator(String sortBy, String orderBy) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/FindAllApplicationsQuery.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/FindAllApplicationsQuery.java
@@ -18,6 +18,7 @@ public record FindAllApplicationsQuery(
     String clientFirstName,
     String clientLastName,
     LocalDate clientDateOfBirth,
+    Boolean isAutoGranted,
     String sortBy,
     String orderBy,
     Integer page,

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/CreateApplicationInMemoryTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/CreateApplicationInMemoryTest.java
@@ -29,11 +29,19 @@ import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataI
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataRepository;
 import uk.gov.justice.laa.dstew.access.model.ApplicationCreateRequest;
 import uk.gov.justice.laa.dstew.access.model.ApplicationHistoryResponse;
+import uk.gov.justice.laa.dstew.access.model.ApplicationResponse;
 import uk.gov.justice.laa.dstew.access.model.ApplicationStatus;
 import uk.gov.justice.laa.dstew.access.model.ApplicationSummaryResponse;
+import uk.gov.justice.laa.dstew.access.model.DecisionStatus;
 import uk.gov.justice.laa.dstew.access.model.DomainEventType;
+import uk.gov.justice.laa.dstew.access.model.EventHistoryRequest;
 import uk.gov.justice.laa.dstew.access.model.IndividualType;
 import uk.gov.justice.laa.dstew.access.model.IndividualsResponse;
+import uk.gov.justice.laa.dstew.access.model.MakeDecisionProceedingRequest;
+import uk.gov.justice.laa.dstew.access.model.MakeDecisionRequest;
+import uk.gov.justice.laa.dstew.access.model.MeritsDecisionDetailsRequest;
+import uk.gov.justice.laa.dstew.access.model.MeritsDecisionStatus;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadRepository;
 import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
@@ -228,6 +236,7 @@ class CreateApplicationInMemoryTest {
     assertThat(projected.getApplicationId()).isEqualTo(applicationId);
     assertThat(projected.getApplyApplicationId()).isEqualTo(applyApplicationId);
     assertThat(projected.getStatus()).isEqualTo(ApplicationStatus.APPLICATION_SUBMITTED.name());
+    assertThat(projected.getAutoGranted()).isNull();
     assertThat(projected.getLaaReference()).isEqualTo("LAA-123");
     assertThat(projected.getOfficeCode()).isEqualTo("1A001B");
     assertThat(projected.getSchemaVersion()).isEqualTo(2);
@@ -271,6 +280,175 @@ class CreateApplicationInMemoryTest {
     var processors = axonConfiguration.getComponents(StreamingEventProcessor.class);
     assertThat(processors.get("application-projection")).isNotNull();
     assertThat(processors.get("application-history-projection")).isNotNull();
+  }
+
+  @Test
+  void givenSubmittedApplication_whenMarkedReady_thenOnlyFalseOutcomeEntersManualList() {
+    UUID applicationId = UUID.randomUUID();
+    applicationId(
+        restTemplate.postForEntity(
+            "/api/v0/applications",
+            new HttpEntity<>(
+                validCreateApplicationRequest(applicationId, UUID.randomUUID()), headers()),
+            Void.class));
+    awaitProjection(applicationId);
+
+    ResponseEntity<ApplicationResponse> directBeforeReady =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId,
+            HttpMethod.GET,
+            new HttpEntity<>(headers()),
+            ApplicationResponse.class);
+    assertThat(directBeforeReady.getBody()).isNotNull();
+    assertThat(directBeforeReady.getBody().getAutoGrant()).isNull();
+
+    ResponseEntity<ApplicationSummaryResponse> before =
+        restTemplate.exchange(
+            "/api/v0/applications?status=APPLICATION_SUBMITTED&isAutoGranted=false",
+            HttpMethod.GET,
+            new HttpEntity<>(headers()),
+            ApplicationSummaryResponse.class);
+    assertThat(before.getBody()).isNotNull();
+    assertThat(before.getBody().getApplications())
+        .extracting(application -> application.getApplicationId())
+        .doesNotContain(applicationId);
+
+    ReadyApplicationRequest request = new ReadyApplicationRequest().applicationVersion(0L);
+    ResponseEntity<Void> ready =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId + "/ready",
+            HttpMethod.PATCH,
+            new HttpEntity<>(request, headers()),
+            Void.class);
+    assertThat(ready.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+
+    ApplicationReadModel projected = awaitApplicationVersion(applicationId, 1L);
+    assertThat(projected.getStatus()).isEqualTo(ApplicationStatus.APPLICATION_SUBMITTED.name());
+    assertThat(projected.getAutoGranted()).isFalse();
+
+    ResponseEntity<ApplicationResponse> direct =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId,
+            HttpMethod.GET,
+            new HttpEntity<>(headers()),
+            ApplicationResponse.class);
+    assertThat(direct.getBody()).isNotNull();
+    assertThat(direct.getBody().getStatus()).isEqualTo(ApplicationStatus.APPLICATION_SUBMITTED);
+    assertThat(direct.getBody().getAutoGrant()).isFalse();
+
+    ResponseEntity<ApplicationSummaryResponse> after =
+        restTemplate.exchange(
+            "/api/v0/applications?status=APPLICATION_SUBMITTED&isAutoGranted=false",
+            HttpMethod.GET,
+            new HttpEntity<>(headers()),
+            ApplicationSummaryResponse.class);
+    assertThat(after.getBody()).isNotNull();
+    assertThat(after.getBody().getApplications())
+        .filteredOn(application -> application.getApplicationId().equals(applicationId))
+        .singleElement()
+        .satisfies(application -> assertThat(application.getAutoGrant()).isFalse());
+
+    ResponseEntity<Void> replay =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId + "/ready",
+            HttpMethod.PATCH,
+            new HttpEntity<>(request, headers()),
+            Void.class);
+    assertThat(replay.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  void givenStaleVersion_whenMarkedReady_thenReturnsConflict() {
+    UUID applicationId = UUID.randomUUID();
+    applicationId(
+        restTemplate.postForEntity(
+            "/api/v0/applications",
+            new HttpEntity<>(
+                validCreateApplicationRequest(applicationId, UUID.randomUUID()), headers()),
+            Void.class));
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId + "/ready",
+            HttpMethod.PATCH,
+            new HttpEntity<>(new ReadyApplicationRequest().applicationVersion(9L), headers()),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody()).contains("version 9 not found");
+  }
+
+  @Test
+  void givenApplicationInProgress_whenMarkedReady_thenReturnsUnprocessableEntity() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationCreateRequest submitted =
+        validCreateApplicationRequest(applicationId, UUID.randomUUID());
+    ApplicationCreateRequest inProgress =
+        ApplicationCreateRequest.builder()
+            .applicationType(submitted.getApplicationType())
+            .status(ApplicationStatus.APPLICATION_IN_PROGRESS)
+            .applicationContent(submitted.getApplicationContent())
+            .laaReference(submitted.getLaaReference())
+            .individuals(submitted.getIndividuals())
+            .build();
+    applicationId(
+        restTemplate.postForEntity(
+            "/api/v0/applications", new HttpEntity<>(inProgress, headers()), Void.class));
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId + "/ready",
+            HttpMethod.PATCH,
+            new HttpEntity<>(new ReadyApplicationRequest().applicationVersion(0L), headers()),
+            String.class);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(422);
+    assertThat(response.getBody()).contains("APPLICATION_IN_PROGRESS");
+  }
+
+  @Test
+  void givenAutomaticallyGrantedApplication_whenMarkedReady_thenReturnsConflict() {
+    UUID applicationId = UUID.randomUUID();
+    applicationId(
+        restTemplate.postForEntity(
+            "/api/v0/applications",
+            new HttpEntity<>(
+                validCreateApplicationRequest(applicationId, UUID.randomUUID()), headers()),
+            Void.class));
+    UUID proceedingId = awaitProjection(applicationId).getProceedings().getFirst().proceedingId();
+    MakeDecisionRequest decision =
+        MakeDecisionRequest.builder()
+            .applicationVersion(0L)
+            .overallDecision(DecisionStatus.GRANTED)
+            .autoGranted(true)
+            .certificate(java.util.Map.of("certificateNumber", "AUTO-1"))
+            .eventHistory(EventHistoryRequest.builder().eventDescription("Auto-granted").build())
+            .proceedings(
+                List.of(
+                    MakeDecisionProceedingRequest.builder()
+                        .proceedingId(proceedingId)
+                        .meritsDecision(
+                            MeritsDecisionDetailsRequest.builder()
+                                .decision(MeritsDecisionStatus.GRANTED)
+                                .justification("All automatic checks passed")
+                                .build())
+                        .build()))
+            .build();
+    restTemplate.exchange(
+        "/api/v0/applications/" + applicationId + "/decision",
+        HttpMethod.PATCH,
+        new HttpEntity<>(decision, headers()),
+        Void.class);
+
+    ResponseEntity<String> response =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applicationId + "/ready",
+            HttpMethod.PATCH,
+            new HttpEntity<>(new ReadyApplicationRequest().applicationVersion(1L), headers()),
+            String.class);
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody()).contains("incompatible auto-grant outcome");
   }
 
   @Test
@@ -655,6 +833,18 @@ class CreateApplicationInMemoryTest {
                     .query(new FindApplicationByIdQuery(applicationId), ApplicationReadModel.class)
                     .join(),
             Objects::nonNull);
+  }
+
+  private ApplicationReadModel awaitApplicationVersion(UUID applicationId, long version) {
+    return await()
+        .atMost(10, TimeUnit.SECONDS)
+        .pollInterval(50, TimeUnit.MILLISECONDS)
+        .until(
+            () ->
+                queryGateway
+                    .query(new FindApplicationByIdQuery(applicationId), ApplicationReadModel.class)
+                    .join(),
+            application -> application != null && application.getApplicationVersion() == version);
   }
 
   private List<ApplicationHistoryReadModel> awaitHistory(UUID applicationId, int expectedCount) {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/EventProcessorRecoveryInMemoryTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/EventProcessorRecoveryInMemoryTest.java
@@ -27,9 +27,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.justice.laa.dstew.access.model.ApplicationCreateRequest;
+import uk.gov.justice.laa.dstew.access.model.ApplicationResponse;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadRepository;
 import uk.gov.justice.laa.dstew.access.query.application.history.ApplicationHistoryReadRepository;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadRepository;
@@ -97,6 +100,30 @@ class EventProcessorRecoveryInMemoryTest {
                             .size()
                         >= 2);
 
+    assertThat(
+            restTemplate
+                .exchange(
+                    "/api/v0/applications/" + applicationId + "/ready",
+                    HttpMethod.PATCH,
+                    new HttpEntity<>(new ReadyApplicationRequest().applicationVersion(0L), headers),
+                    Void.class)
+                .getStatusCode())
+        .isEqualTo(HttpStatus.NO_CONTENT);
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        restTemplate
+                            .exchange(
+                                "/api/v0/applications/" + applicationId,
+                                HttpMethod.GET,
+                                new HttpEntity<>(headers),
+                                ApplicationResponse.class)
+                            .getBody()
+                            .getAutoGrant())
+                    .isFalse());
+
     var processors =
         java.util.List.of(
             processor("application-projection"),
@@ -124,6 +151,16 @@ class EventProcessorRecoveryInMemoryTest {
                             .findAllByApplicationIdOrderByOccurredAtAsc(linkedApplicationId)
                             .size()
                         >= 2);
+    assertThat(
+            restTemplate
+                .exchange(
+                    "/api/v0/applications/" + applicationId,
+                    HttpMethod.GET,
+                    new HttpEntity<>(headers),
+                    ApplicationResponse.class)
+                .getBody()
+                .getAutoGrant())
+        .isFalse();
     assertThat(processors)
         .allSatisfy(
             processor -> {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/ProjectionTimeoutInMemoryTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/ProjectionTimeoutInMemoryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreateRequestFixture.validCreateApplicationRequest;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.junit.jupiter.api.Test;
@@ -13,11 +15,13 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import uk.gov.justice.laa.dstew.access.model.ApplicationCreateRequest;
+import uk.gov.justice.laa.dstew.access.model.ApplicationResponse;
 
 /**
  * Verifies that when the application-projection tracking processor is stopped the controller
@@ -52,11 +56,11 @@ class ProjectionTimeoutInMemoryTest {
   @Test
   void givenStoppedProjectionProcessor_whenPostApplication_thenReturnsAcceptedWithLocation() {
     // Stop the projection processor so no QueryUpdateEmitter.emit can be called for this command.
-    axonConfiguration
-        .getComponents(StreamingEventProcessor.class)
-        .get("application-projection")
-        .shutdown()
-        .join();
+    StreamingEventProcessor processor =
+        axonConfiguration
+            .getComponents(StreamingEventProcessor.class)
+            .get("application-projection");
+    processor.shutdown().join();
 
     UUID applyApplicationId = UUID.randomUUID();
     ApplicationCreateRequest request =
@@ -86,5 +90,21 @@ class ProjectionTimeoutInMemoryTest {
 
     // The test must complete well below the full 5-second default timeout.
     assertThat(elapsedMs).isLessThan(3_000L);
+
+    CompletableFuture<Void> restart =
+        CompletableFuture.runAsync(
+            () -> processor.start().join(),
+            CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS));
+    ResponseEntity<ApplicationResponse> directRead =
+        restTemplate.exchange(
+            "/api/v0/applications/" + applyApplicationId,
+            HttpMethod.GET,
+            new HttpEntity<>(headers),
+            ApplicationResponse.class);
+
+    restart.join();
+    assertThat(directRead.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(directRead.getBody()).isNotNull();
+    assertThat(directRead.getBody().getApplicationId()).isEqualTo(applyApplicationId);
   }
 }

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationAggregateTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationAggregateTest.java
@@ -29,9 +29,14 @@ import uk.gov.justice.laa.dstew.access.command.application.decision.MakeApplicat
 import uk.gov.justice.laa.dstew.access.command.application.decision.MakeDecisionProceeding;
 import uk.gov.justice.laa.dstew.access.command.application.linkedgroup.CreateLinkedApplicationGroupCommand;
 import uk.gov.justice.laa.dstew.access.command.application.linkedgroup.LinkedApplicationGroupRequested;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.MarkApplicationReadyCommand;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ReadyApplicationResult;
+import uk.gov.justice.laa.dstew.access.exception.ApplicationAutoGrantOutcomeConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationCreationConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationGroupInvariantException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationVersionConflictException;
+import uk.gov.justice.laa.dstew.access.exception.InvalidApplicationStateException;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
 
@@ -268,6 +273,127 @@ class ApplicationAggregateTest {
         .command(decisionCommand(applicationId, 1L, proceedingId, "REFUSED", "justification", null))
         .then()
         .exception(ApplicationVersionConflictException.class)
+        .noEvents();
+  }
+
+  @Test
+  void givenSubmittedUnassessedApplication_whenMarkedReady_thenStoresFalseOutcomeAndEmitsEvent() {
+    UUID applicationId = UUID.randomUUID();
+    Instant occurredAt = Instant.parse("2026-07-21T09:30:00Z");
+    ApplicationCreationDetails details = applicationCreationDetails(applicationId);
+    when(applicationDataStore.get(applicationId, 0L))
+        .thenReturn(ApplicationDataPayload.from(details));
+    when(applicationDataStore.append(any(), anyLong(), any(), any(), any())).thenReturn("hash");
+
+    fixture
+        .given()
+        .events(applicationCreatedEvent(applicationId, details))
+        .when()
+        .command(new MarkApplicationReadyCommand(applicationId, 0L, "{}", occurredAt))
+        .then()
+        .resultMessagePayload(ReadyApplicationResult.RECORDED)
+        .events(new ApplicationReadyForManualAssessmentEvent(applicationId, 1L, 1L, occurredAt));
+  }
+
+  @Test
+  void givenApplicationDataCannotBeAppended_whenMarkedReady_thenDoesNotEmitEvent() {
+    UUID applicationId = UUID.randomUUID();
+    Instant occurredAt = Instant.parse("2026-07-21T09:30:00Z");
+    ApplicationCreationDetails details = applicationCreationDetails(applicationId);
+    when(applicationDataStore.get(applicationId, 0L))
+        .thenReturn(ApplicationDataPayload.from(details));
+    when(applicationDataStore.append(any(), anyLong(), any(), any(), any()))
+        .thenThrow(new IllegalStateException("application data unavailable"));
+
+    fixture
+        .given()
+        .events(applicationCreatedEvent(applicationId, details))
+        .when()
+        .command(new MarkApplicationReadyCommand(applicationId, 0L, "{}", occurredAt))
+        .then()
+        .exception(IllegalStateException.class)
+        .noEvents();
+  }
+
+  @Test
+  void givenAlreadyManualApplication_whenMarkedReadyAgain_thenSucceedsWithoutAnotherEvent() {
+    UUID applicationId = UUID.randomUUID();
+    Instant firstOccurredAt = Instant.parse("2026-07-21T09:30:00Z");
+
+    fixture
+        .given()
+        .events(
+            applicationCreatedEvent(applicationId),
+            new ApplicationReadyForManualAssessmentEvent(applicationId, 1L, 1L, firstOccurredAt))
+        .when()
+        .command(
+            new MarkApplicationReadyCommand(
+                applicationId, 0L, "{}", Instant.parse("2026-07-21T09:31:00Z")))
+        .then()
+        .resultMessagePayload(ReadyApplicationResult.ALREADY_RECORDED)
+        .noEvents();
+  }
+
+  @Test
+  void givenAutomaticallyGrantedApplication_whenMarkedReady_thenRejectsIncompatibleOutcome() {
+    UUID applicationId = UUID.randomUUID();
+
+    fixture
+        .given()
+        .events(
+            applicationCreatedEvent(applicationId),
+            new ApplicationDecisionMadeEvent(
+                applicationId, 1L, 1L, "GRANTED", true, Instant.parse("2026-07-21T09:00:00Z")))
+        .when()
+        .command(
+            new MarkApplicationReadyCommand(
+                applicationId, 1L, "{}", Instant.parse("2026-07-21T09:31:00Z")))
+        .then()
+        .exception(ApplicationAutoGrantOutcomeConflictException.class)
+        .noEvents();
+  }
+
+  @Test
+  void givenUnassessedApplicationAndStaleVersion_whenMarkedReady_thenRejectsConflict() {
+    UUID applicationId = UUID.randomUUID();
+
+    fixture
+        .given()
+        .events(applicationCreatedEvent(applicationId))
+        .when()
+        .command(
+            new MarkApplicationReadyCommand(
+                applicationId, 2L, "{}", Instant.parse("2026-07-21T09:31:00Z")))
+        .then()
+        .exception(ApplicationVersionConflictException.class)
+        .noEvents();
+  }
+
+  @Test
+  void givenApplicationInProgress_whenMarkedReady_thenRejectsInvalidState() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationCreatedEvent inProgress =
+        new ApplicationCreatedEvent(
+            applicationId,
+            0L,
+            "fingerprint",
+            "APPLICATION_IN_PROGRESS",
+            1,
+            "APPLY",
+            applicationId,
+            Instant.parse("2026-07-21T09:00:00Z"),
+            null,
+            List.of());
+
+    fixture
+        .given()
+        .events(inProgress)
+        .when()
+        .command(
+            new MarkApplicationReadyCommand(
+                applicationId, 0L, "{}", Instant.parse("2026-07-21T09:31:00Z")))
+        .then()
+        .exception(InvalidApplicationStateException.class)
         .noEvents();
   }
 

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/ApplicationExceptionHandlerTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/ApplicationExceptionHandlerTest.java
@@ -6,9 +6,11 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import uk.gov.justice.laa.dstew.access.exception.ApplicationAutoGrantOutcomeConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationCreationConflictException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationGroupInvariantException;
 import uk.gov.justice.laa.dstew.access.exception.ApplicationVersionConflictException;
+import uk.gov.justice.laa.dstew.access.exception.InvalidApplicationStateException;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 import uk.gov.justice.laa.dstew.access.validation.ValidationException;
 
@@ -99,5 +101,35 @@ class ApplicationExceptionHandlerTest {
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     assertThat(response.getBody().getDetail()).isEqualTo("Application cannot be its own lead");
+  }
+
+  @Test
+  void givenIncompatibleAutoGrantOutcome_whenHandled_thenReturnsConflict() {
+    UUID applicationId = UUID.randomUUID();
+
+    var response =
+        handler.handleApplicationAutoGrantOutcomeConflictException(
+            new ApplicationAutoGrantOutcomeConflictException(applicationId));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    assertThat(response.getBody().getDetail())
+        .isEqualTo(
+            "Application " + applicationId + " already has an incompatible auto-grant outcome");
+  }
+
+  @Test
+  void givenInvalidLifecycleState_whenHandled_thenReturnsUnprocessableEntity() {
+    UUID applicationId = UUID.randomUUID();
+
+    var response =
+        handler.handleInvalidApplicationStateException(
+            new InvalidApplicationStateException(applicationId, "APPLICATION_IN_PROGRESS"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_CONTENT);
+    assertThat(response.getBody().getDetail())
+        .isEqualTo(
+            "Application "
+                + applicationId
+                + " cannot be made ready from status APPLICATION_IN_PROGRESS");
   }
 }

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandControllerTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandControllerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -18,7 +19,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
 import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationCommand;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerService;
+import uk.gov.justice.laa.dstew.access.command.application.ready.MarkApplicationReadyCommand;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ReadyApplicationResult;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
 import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
 
 /**
@@ -29,11 +33,13 @@ import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
 class ApplicationCommandControllerTest {
 
   private CommandGateway commandGateway;
+  private ReadyApplicationCommandMapper readyApplicationCommandMapper;
   private ApplicationCommandController controller;
 
   @BeforeEach
   void setUp() {
     commandGateway = mock(CommandGateway.class);
+    readyApplicationCommandMapper = mock(ReadyApplicationCommandMapper.class);
     controller =
         new ApplicationCommandController(
             commandGateway,
@@ -43,7 +49,38 @@ class ApplicationCommandControllerTest {
             mock(AssignCaseworkerService.class),
             mock(AssignCaseworkerRequestMapper.class),
             mock(UnassignCaseworkerRequestMapper.class),
-            mock(CreateNoteCommandMapper.class));
+            mock(CreateNoteCommandMapper.class),
+            readyApplicationCommandMapper);
+  }
+
+  @Test
+  void givenReadinessRecorded_whenMarkApplicationReady_thenReturnsNoContent() {
+    UUID applicationId = UUID.randomUUID();
+    ReadyApplicationRequest request = new ReadyApplicationRequest().applicationVersion(2L);
+    MarkApplicationReadyCommand command =
+        new MarkApplicationReadyCommand(applicationId, 2L, "{}", Instant.now());
+    when(readyApplicationCommandMapper.toCommand(applicationId, request)).thenReturn(command);
+    when(commandGateway.sendAndWait(command, ReadyApplicationResult.class))
+        .thenReturn(ReadyApplicationResult.RECORDED);
+
+    var response = controller.markApplicationReady(null, applicationId, request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(204);
+  }
+
+  @Test
+  void givenReadinessAlreadyRecorded_whenMarkApplicationReady_thenReturnsOk() {
+    UUID applicationId = UUID.randomUUID();
+    ReadyApplicationRequest request = new ReadyApplicationRequest().applicationVersion(2L);
+    MarkApplicationReadyCommand command =
+        new MarkApplicationReadyCommand(applicationId, 2L, "{}", Instant.now());
+    when(readyApplicationCommandMapper.toCommand(applicationId, request)).thenReturn(command);
+    when(commandGateway.sendAndWait(command, ReadyApplicationResult.class))
+        .thenReturn(ReadyApplicationResult.ALREADY_RECORDED);
+
+    var response = controller.markApplicationReady(null, applicationId, request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(200);
   }
 
   @Test

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ReadyApplicationCommandMapperTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ReadyApplicationCommandMapperTest.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.dstew.access.controller.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+import uk.gov.justice.laa.dstew.access.model.ReadyApplicationRequest;
+
+class ReadyApplicationCommandMapperTest {
+
+  private final ReadyApplicationCommandMapper mapper =
+      new ReadyApplicationCommandMapper(JsonMapper.builder().build());
+
+  @Test
+  void givenReadyRequest_whenMapped_thenPreservesVersionAndAuditPayload() {
+    UUID applicationId = UUID.randomUUID();
+    ReadyApplicationRequest request = new ReadyApplicationRequest().applicationVersion(4L);
+    Instant before = Instant.now();
+
+    var command = mapper.toCommand(applicationId, request);
+
+    assertThat(command.applicationId()).isEqualTo(applicationId);
+    assertThat(command.expectedApplicationVersion()).isEqualTo(4L);
+    assertThat(command.serialisedRequest()).isEqualTo("{\"applicationVersion\":4}");
+    assertThat(command.occurredAt()).isBetween(before, Instant.now());
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/SubscriptionProjectionGatewayTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/SubscriptionProjectionGatewayTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -140,6 +141,31 @@ class SubscriptionProjectionGatewayTest {
     gateway.awaitProjection(query(), ApplicationReadModel.class, () -> {});
 
     assertThat(cancelled).isTrue();
+  }
+
+  @Test
+  void givenDelayedResult_whenFindProjection_thenReturnsFirstAvailableProjection() {
+    ApplicationReadModel notification = mock(ApplicationReadModel.class);
+    ApplicationReadModel hydrated = mock(ApplicationReadModel.class);
+    FindApplicationByIdQuery query = query();
+    subscription(Mono.delay(Duration.ofMillis(10)).map(ignored -> notification));
+    when(queryGateway.query(query, ApplicationReadModel.class))
+        .thenReturn(java.util.concurrent.CompletableFuture.completedFuture(hydrated));
+
+    Optional<ApplicationReadModel> result =
+        gateway.findProjection(query, ApplicationReadModel.class);
+
+    assertThat(result).contains(hydrated);
+  }
+
+  @Test
+  void givenNoResultBeforeTimeout_whenFindProjection_thenReturnsEmpty() {
+    subscription(Mono.never());
+
+    Optional<ApplicationReadModel> result =
+        gateway.findProjection(query(), ApplicationReadModel.class);
+
+    assertThat(result).isEmpty();
   }
 
   // ── helpers ───────────────────────────────────────────────────────────────

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
@@ -11,6 +11,8 @@ import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreatedEventF
 import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreatedEventFixture.applicationCreationDetails;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -26,6 +28,7 @@ import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataP
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataStore;
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationNote;
 import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadRepository;
 
 class ApplicationProjectionTest {
@@ -142,6 +145,25 @@ class ApplicationProjectionTest {
   }
 
   @Test
+  void givenReadyEvent_whenHandled_thenAdvancesReferencedDataVersion() {
+    UUID applicationId = UUID.randomUUID();
+    Instant occurredAt = Instant.parse("2026-07-21T09:30:00Z");
+    ApplicationReadModel existing =
+        ApplicationReadModel.builder().applicationId(applicationId).build();
+    when(applicationReadRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+    when(applicationReadRepository.save(existing)).thenReturn(existing);
+
+    projection.on(
+        new ApplicationReadyForManualAssessmentEvent(applicationId, 1L, 1L, occurredAt),
+        queryUpdateEmitter);
+
+    assertThat(existing.getStatus()).isNull();
+    assertThat(existing.getApplicationVersion()).isEqualTo(1L);
+    assertThat(existing.getApplicationDataVersion()).isEqualTo(1L);
+    assertThat(existing.getModifiedAt()).isEqualTo(occurredAt);
+  }
+
+  @Test
   void givenAssignmentEvent_whenHandled_thenSetsCaseworkerAndVersions() {
     UUID applicationId = UUID.randomUUID();
     UUID caseworkerId = UUID.randomUUID();
@@ -255,5 +277,57 @@ class ApplicationProjectionTest {
 
     assertThat(result).isNotNull();
     assertThat(result.notes()).isEmpty();
+  }
+
+  @Test
+  void givenSubmittedApplications_whenManualOutcomeRequested_thenExcludesUnassessedApplication() {
+    UUID unassessedId = UUID.randomUUID();
+    UUID manualId = UUID.randomUUID();
+    ApplicationReadModel unassessed = readModel(unassessedId);
+    ApplicationReadModel manual = readModel(manualId);
+    ApplicationDataPayload unassessedData =
+        ApplicationDataPayload.from(applicationCreationDetails(unassessedId));
+    ApplicationDataPayload manualData =
+        ApplicationDataPayload.from(applicationCreationDetails(manualId))
+            .withManualAssessmentRequired();
+    when(applicationReadRepository.findAll()).thenReturn(List.of(unassessed, manual));
+    when(applicationDataStore.getAll(any()))
+        .thenReturn(
+            Map.of(
+                new uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataId(
+                    unassessedId, 0L),
+                unassessedData,
+                new uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataId(
+                    manualId, 0L),
+                manualData));
+
+    FindAllApplicationsResult result =
+        projection.handle(
+            new FindAllApplicationsQuery(
+                "APPLICATION_SUBMITTED",
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                "SUBMITTED_DATE",
+                "ASC",
+                1,
+                20));
+
+    assertThat(result.applications())
+        .extracting(ApplicationReadModel::getApplicationId)
+        .containsExactly(manualId);
+  }
+
+  private ApplicationReadModel readModel(UUID applicationId) {
+    return ApplicationReadModel.builder()
+        .applicationId(applicationId)
+        .status("APPLICATION_SUBMITTED")
+        .applicationDataVersion(0L)
+        .applicationVersion(0L)
+        .modifiedAt(Instant.parse("2026-07-21T09:00:00Z"))
+        .build();
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2093)

Updated the Axon Data Access service so manual-task visibility is controlled by the persisted auto-grant outcome rather than Application Status.

Submitted Applications now retain  autoGrant=null  and remain hidden from Civil Decide's manual task list while automatic assessment is pending. A new version-safe  PATCH /api/v0/applications/{id}/ready  operation records  autoGrant=false  without changing the Application Status or creating a Decision. The Axon aggregate persists this as a new immutable data version and a thin replayable event, allowing projections to reconstruct the outcome safely.

The caseworker-facing query now supports filtering submitted Applications by  isAutoGranted=false , exposing only Applications deliberately routed for manual assessment. The operation also handles replay, stale versions, incompatible outcomes, and invalid lifecycle states with distinct responses.

Added unit, in-memory, replay, and PostgreSQL integration coverage, along with architecture and usage documentation.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
