### PR TITLE
feat: DSTEW-2084 - GetAllApplications Filter Projection

### DIFF
--- a/data-access-service-axon/docs/application-list-projection.md
+++ b/data-access-service-axon/docs/application-list-projection.md
@@ -1,0 +1,87 @@
+# Application List Projection with Query-Time Rehydration
+
+## Background
+
+The `GET /applications` endpoint supports paginated, filterable queries across all applications. Each application's rich content — client PII, proceedings, certificate, application content — is stored as a versioned JSONB payload in the `application_data` table, deliberately separated from the event log for GDPR reasons.
+
+This separation created a query problem: filters such as client name or date of birth could not be pushed to the database because the values lived inside opaque JSONB blobs. PostgreSQL can query inside JSONB using operators such as `->>` or `jsonb_path_query`, but doing so requires either a full table scan (no index support for arbitrary nested paths) or maintaining GIN indexes on the entire document — neither of which is practical for filtered, sorted, paginated queries across a large dataset.
+
+The only alternatives were:
+- **Load all application payloads into memory** before filtering — not scalable as the dataset grows, and forces the application to do work the database should do
+- **Duplicate the entire payload into the read model table** — expensive to maintain during event replay and bloats the projection with data that is only needed for the response body, not for filtering
+
+Neither option is acceptable at scale. The thin list index solves this by extracting only the filterable fields into discrete, properly typed and indexed columns, while leaving the full payload in `application_data` where it is only loaded for the final result page.
+
+## What Was Introduced
+
+### New database table: `application_list_index` (V15 migration)
+
+A thin, purpose-built projection table containing only the columns needed for filtering, sorting, counting, and paging the list endpoint. Rich response-only fields are explicitly excluded.
+
+**Filterable/sortable columns stored:**
+- `status`, `laa_reference`, `matter_type`, `caseworker_id`
+- `client_first_name`, `client_last_name`, `client_date_of_birth` — minimum PII required to support client name and DOB filter pushdown
+- `lead_application_id`, `submitted_at`, `is_auto_granted`
+
+**Bookkeeping columns:**
+- `stream_version` — the application domain version at the time the row was last written; used as an optimistic concurrency guard
+- `projection_position` — tracks the event position at which the row was last written
+
+**Indexes created:**
+
+Without indexes, every filtered query against the list endpoint would require a full sequential scan of the `application_list_index` table — reading every row regardless of how many match the filter. As the table grows this becomes progressively slower and more expensive.
+
+- **Equality indexes** on `status`, `matter_type`, `laa_reference`, `caseworker_id` — allow PostgreSQL to seek directly to matching rows rather than scanning the full table when these filters are applied
+- **Functional indexes** on `lower(client_first_name)` and `lower(client_last_name)` — client name filters use a case-insensitive `LIKE 'value%'` predicate (e.g. searching "jane" should match "Jane" or "JANE"). A standard B-tree index on the raw column would not be used by a `lower(column)` expression, so functional indexes on the pre-lowercased value are required. The `ApplicationListIndexSpecification` applies `lower()` consistently to match these indexes, ensuring PostgreSQL uses them rather than falling back to a sequential scan
+
+### `ApplicationListIndexProjection`
+
+An Axon `@EventHandler` component that maintains the list index in response to domain events:
+
+| Event | Action |
+|---|---|
+| `ApplicationCreatedEvent` | Inserts a new index row; fetches client PII from `application_data` at this point |
+| `ApplicationLinkedEvent` | Updates `lead_application_id` |
+| `ApplicationDecisionMadeEvent` | Updates `status` and `is_auto_granted` |
+| `ApplicationAssignedToCaseworkerEvent` | Updates `caseworker_id` |
+| `ApplicationUnassignedFromCaseworkerEvent` | Clears `caseworker_id` |
+| `NoteCreatedEvent` | Updates `projection_position` only (no filter fields change) |
+
+Supports `@ResetHandler` — the table is wiped and fully rebuilt from the event log on replay.
+
+### `ApplicationListIndexSpecification`
+
+A Spring Data JPA `Specification` factory that converts `FindAllApplicationsQuery` filter parameters into database predicates. All non-null filters produce a PostgreSQL predicate. Client name filters use `lower()` to match the functional indexes in the V15 migration.
+
+### `ApplicationListIndexReadRepository`
+
+A Spring Data JPA repository extending both `JpaRepository` and `JpaSpecificationExecutor`, providing filtered pagination support against the list index table.
+
+### Refactored `FindAllApplicationsQuery` handler
+
+The `ApplicationProjection.handle(FindAllApplicationsQuery)` method was refactored to a two-phase approach:
+
+**Phase 1 — database:** Query `application_list_index` with all filters, sort, and pagination applied entirely in PostgreSQL. Returns a page of `applicationId`s.
+
+**Phase 2 — batch rehydration:** For the result page only:
+1. Batch-load `application_current_state` rows for those IDs (`findAllById`)
+2. Batch-load `application_data` payloads for those IDs (`getAll`)
+3. Merge into full `ApplicationReadModel` objects in memory
+
+## Key Benefits
+
+**Filter pushdown to the database.** Filtering by client name, DOB, status, matter type, and LAA reference now executes entirely in PostgreSQL against indexed columns. No application payloads are loaded until after paging has been applied.
+
+**Elimination of N+1 queries.** The list endpoint now makes exactly two batch reads regardless of page size — one to `application_current_state`, one to `application_data` — rather than one query per application.
+
+**Scalability.** COUNT and pagination happen on the thin index table, not against the full JSONB payload store. As the number of applications grows, query performance degrades gradually rather than sharply.
+
+**Full replayability.** The list index is a standard Axon event-sourced projection. It can be wiped and rebuilt from the event log at any time without data loss or manual intervention.
+
+**GDPR positioning preserved.** PII remains confined to `application_data` (JSONB payload) and the three denormalised columns in `application_list_index`. It is not duplicated into the event log. A right-to-erasure implementation would target only these two known locations.
+
+## Considerations
+
+- **`projectionPosition` semantics:** The field is populated using `message.getIdentifier().hashCode()` — a hash of a string UUID into an `int`. This will not be monotonically increasing and cannot reliably measure projection lag against `domain_event_entry.global_index` as the Javadoc describes. The actual Axon token position would be needed for that purpose.
+- **Dual projection maintenance:** `ApplicationListIndexProjection` handles the same events as `ApplicationProjection`. New domain events will need to be assessed and wired into both projections.
+- **`caseworker_id` filter not yet exposed:** The column and its index exist in V15, but `caseworker_id` is not yet a filter parameter in `FindAllApplicationsQuery` or `ApplicationListIndexSpecification`. It is in place for a future filter.

--- a/data-access-service-axon/src/integrationTest/java/uk/gov/justice/laa/dstew/access/PostgresAxonIntegrationTest.java
+++ b/data-access-service-axon/src/integrationTest/java/uk/gov/justice/laa/dstew/access/PostgresAxonIntegrationTest.java
@@ -158,12 +158,13 @@ class PostgresAxonIntegrationTest {
             """,
             String.class);
 
-    assertThat(appliedVersions).containsExactly("1", "2");
+    assertThat(appliedVersions).containsExactly("1", "2", "3");
     assertThat(tables)
         .containsExactly(
             "application_current_state",
             "application_data",
             "application_history",
+            "application_list_index",
             "caseworkers",
             "domain_event_entry",
             "flyway_schema_history",
@@ -173,12 +174,12 @@ class PostgresAxonIntegrationTest {
     assertThat(
             jdbcTemplate.queryForObject(
                 """
-                SELECT is_nullable
-                FROM information_schema.columns
-                WHERE table_schema = 'axon'
-                  AND table_name = 'token_entry'
-                  AND column_name = 'mask'
-                """,
+            SELECT is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'axon'
+              AND table_name = 'token_entry'
+              AND column_name = 'mask'
+            """,
                 String.class))
         .isEqualTo("NO");
   }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
@@ -1,11 +1,11 @@
 package uk.gov.justice.laa.dstew.access.query.application;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.axonframework.messaging.core.annotation.Namespace;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
@@ -13,6 +13,10 @@ import org.axonframework.messaging.eventhandling.replay.annotation.ResetHandler;
 import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 import org.axonframework.messaging.queryhandling.annotation.QueryHandler;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationCreatedEvent;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationLinkedEvent;
@@ -26,6 +30,9 @@ import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationD
 import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadRepository;
+import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexReadModel;
+import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexReadRepository;
+import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexSpecification;
 
 /** Independently replayable projection of the current state of each Application. */
 @Component
@@ -35,6 +42,7 @@ public class ApplicationProjection {
   private final ApplicationReadRepository applicationReadRepository;
   private final LinkedApplicationGroupReadRepository groupReadRepository;
   private final ApplicationDataStore applicationDataStore;
+  private final ApplicationListIndexReadRepository listIndexRepository;
 
   /**
    * Constructs the projection with its read repositories and application data store.
@@ -43,14 +51,18 @@ public class ApplicationProjection {
    * @param groupReadRepository persistence interface for {@code
    *     linked_application_group_current_state}; used by {@link FindAllApplicationsQuery} to
    *     batch-fetch group membership for the result page
+   * @param listIndexRepository persistence interface for {@code application_list_index}; used by
+   *     {@link FindAllApplicationsQuery} for database-side filtering and paging
    */
   public ApplicationProjection(
       ApplicationReadRepository applicationReadRepository,
       LinkedApplicationGroupReadRepository groupReadRepository,
-      ApplicationDataStore applicationDataStore) {
+      ApplicationDataStore applicationDataStore,
+      ApplicationListIndexReadRepository listIndexRepository) {
     this.applicationReadRepository = applicationReadRepository;
     this.groupReadRepository = groupReadRepository;
     this.applicationDataStore = applicationDataStore;
+    this.listIndexRepository = listIndexRepository;
   }
 
   /** Returns the current-state projection for the requested Application. */
@@ -84,29 +96,57 @@ public class ApplicationProjection {
   /**
    * Returns a paginated, filtered list of Application projections.
    *
-   * <p>The thin current-state rows are batch-hydrated from their referenced immutable data versions
-   * before filtering, sorting, and pagination. This keeps PII out of the disposable projection.
-   *
-   * <p>Group membership is batch-fetched for the result page and returned in the result so the
-   * response mapper can populate {@code linkedApplications} without additional queries.
+   * <p>Filtering, sorting, counting, and paging are pushed entirely to the database via {@code
+   * application_list_index}. After a page of index rows is returned, {@code application_data}
+   * payloads are bulk-loaded for only those application IDs, avoiding N+1 lookups. Group membership
+   * is similarly batch-fetched for the page and returned so the response mapper can populate {@code
+   * linkedApplications} without additional queries.
    */
   @QueryHandler
   public FindAllApplicationsResult handle(FindAllApplicationsQuery query) {
-    int page = Math.max(0, query.page() - 1);
-    int pageSize = query.pageSize() > 0 ? query.pageSize() : 20;
+    Sort sort = buildSort(query.sortBy(), query.orderBy());
+    Pageable pageable = PageRequest.of(Math.max(0, query.page() - 1), query.pageSize(), sort);
 
-    List<ApplicationReadModel> filtered =
-        hydrate(applicationReadRepository.findAll()).stream()
-            .filter(application -> matches(application, query))
-            .sorted(comparator(query.sortBy(), query.orderBy()))
+    Page<ApplicationListIndexReadModel> indexPage =
+        listIndexRepository.findAll(ApplicationListIndexSpecification.from(query), pageable);
+
+    List<UUID> pageIds =
+        indexPage.getContent().stream()
+            .map(ApplicationListIndexReadModel::getApplicationId)
             .toList();
-    int fromIndex = Math.min(page * pageSize, filtered.size());
-    int toIndex = Math.min(fromIndex + pageSize, filtered.size());
-    List<ApplicationReadModel> content = filtered.subList(fromIndex, toIndex);
+
+    // Single batch load of current-state rows for the page
+    Map<UUID, ApplicationReadModel> stateById =
+        applicationReadRepository.findAllById(pageIds).stream()
+            .collect(Collectors.toMap(ApplicationReadModel::getApplicationId, Function.identity()));
+
+    // Single batch load of application_data payloads for the page
+    List<ApplicationDataId> dataIds =
+        stateById.values().stream()
+            .map(s -> new ApplicationDataId(s.getApplicationId(), s.getApplicationDataVersion()))
+            .toList();
+    Map<ApplicationDataId, ApplicationDataPayload> dataById = applicationDataStore.getAll(dataIds);
+
+    // Assemble hydrated read models preserving the index ordering
+    List<ApplicationReadModel> content =
+        pageIds.stream()
+            .map(stateById::get)
+            .filter(Objects::nonNull)
+            .map(
+                state -> {
+                  ApplicationDataId id =
+                      new ApplicationDataId(
+                          state.getApplicationId(), state.getApplicationDataVersion());
+                  ApplicationDataPayload data = dataById.get(id);
+                  return data == null ? null : hydrate(state, data);
+                })
+            .filter(Objects::nonNull)
+            .toList();
+
     Map<UUID, LinkedApplicationGroupReadModel> groupsByLeadId = fetchGroups(content);
 
     return new FindAllApplicationsResult(
-        content, groupsByLeadId, filtered.size(), query.page(), pageSize);
+        content, groupsByLeadId, indexPage.getTotalElements(), query.page(), query.pageSize());
   }
 
   /** Creates the current-state row from an Application's creation event. */
@@ -212,24 +252,11 @@ public class ApplicationProjection {
     applicationReadRepository.deleteAllInBatch();
   }
 
-  private boolean matches(ApplicationReadModel application, FindAllApplicationsQuery query) {
-    return (query.status() == null || Objects.equals(application.getStatus(), query.status()))
-        && (query.laaReference() == null
-            || Objects.equals(application.getLaaReference(), query.laaReference()))
-        && (query.matterType() == null
-            || Objects.equals(application.getMatterType(), query.matterType()));
-  }
-
-  private Comparator<ApplicationReadModel> comparator(String sortBy, String orderBy) {
-    Comparator<ApplicationReadModel> comparator =
-        "LAST_UPDATED_DATE".equalsIgnoreCase(sortBy)
-            ? Comparator.comparing(
-                ApplicationReadModel::getModifiedAt,
-                Comparator.nullsLast(Comparator.naturalOrder()))
-            : Comparator.comparing(
-                ApplicationReadModel::getSubmittedAt,
-                Comparator.nullsLast(Comparator.naturalOrder()));
-    return "DESC".equalsIgnoreCase(orderBy) ? comparator.reversed() : comparator;
+  private Sort buildSort(String sortBy, String orderBy) {
+    String property = "LAST_UPDATED_DATE".equalsIgnoreCase(sortBy) ? "modifiedAt" : "submittedAt";
+    Sort.Direction direction =
+        "DESC".equalsIgnoreCase(orderBy) ? Sort.Direction.DESC : Sort.Direction.ASC;
+    return Sort.by(direction, property).and(Sort.by(Sort.Direction.ASC, "applicationId"));
   }
 
   private Optional<ApplicationReadModel> hydrate(ApplicationReadModel application) {
@@ -238,28 +265,6 @@ public class ApplicationProjection {
             application.getApplicationId(), application.getApplicationDataVersion());
     ApplicationDataPayload data = applicationDataStore.getAll(List.of(id)).get(id);
     return data == null ? Optional.empty() : Optional.of(hydrate(application, data));
-  }
-
-  private List<ApplicationReadModel> hydrate(List<ApplicationReadModel> applications) {
-    List<ApplicationDataId> ids =
-        applications.stream()
-            .map(
-                application ->
-                    new ApplicationDataId(
-                        application.getApplicationId(), application.getApplicationDataVersion()))
-            .toList();
-    Map<ApplicationDataId, ApplicationDataPayload> dataById = applicationDataStore.getAll(ids);
-    return applications.stream()
-        .map(
-            application -> {
-              ApplicationDataId id =
-                  new ApplicationDataId(
-                      application.getApplicationId(), application.getApplicationDataVersion());
-              ApplicationDataPayload data = dataById.get(id);
-              return data == null ? null : hydrate(application, data);
-            })
-        .filter(Objects::nonNull)
-        .toList();
   }
 
   private ApplicationReadModel hydrate(
@@ -299,6 +304,6 @@ public class ApplicationProjection {
     return groupReadRepository.findAllByLeadApplicationIdIn(leadIds).stream()
         .collect(
             Collectors.toMap(
-                LinkedApplicationGroupReadModel::getLeadApplicationId, g -> g, (a, b) -> a));
+                LinkedApplicationGroupReadModel::getLeadApplicationId, g -> g, (a, ignored) -> a));
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/FindAllApplicationsQuery.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/FindAllApplicationsQuery.java
@@ -4,12 +4,12 @@ import java.time.LocalDate;
 import uk.gov.justice.laa.dstew.access.query.PaginationHelper;
 
 /**
- * Query to retrieve a paginated, filtered list of Application current-state projections.
+ * Query to retrieve a paginated, filtered list of Applications.
  *
- * <p>{@code clientFirstName}, {@code clientLastName}, and {@code clientDateOfBirth} are accepted
- * for API compatibility but are not yet applied as filters — client data is stored in the {@code
- * individuals} JSON column rather than as plain columns. A future migration can denormalise those
- * fields to enable filtering.
+ * <p>All filter fields including {@code clientFirstName}, {@code clientLastName}, and {@code
+ * clientDateOfBirth} are applied as database predicates against {@code application_list_index}.
+ * After paging, rich response fields are bulk-loaded from {@code application_data} only for the
+ * returned page.
  */
 public record FindAllApplicationsQuery(
     String status,

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexProjection.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexProjection.java
@@ -1,0 +1,168 @@
+package uk.gov.justice.laa.dstew.access.query.application.listindex;
+
+import java.util.List;
+import org.axonframework.messaging.core.annotation.Namespace;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.annotation.EventHandler;
+import org.axonframework.messaging.eventhandling.replay.annotation.ResetHandler;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationIndividual;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationLinkedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationAssignedToCaseworkerEvent;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationUnassignedFromCaseworkerEvent;
+import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataPayload;
+import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataStore;
+import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
+import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
+
+/**
+ * Independently replayable tracking projection that maintains {@code application_list_index}.
+ *
+ * <p>This projection writes PII filter columns ({@code client_first_name}, {@code
+ * client_last_name}, {@code client_date_of_birth}) and other filter/sort fields into the index row
+ * at event-handling time, reading them once from {@code application_data}. This means the list
+ * query can push all filters and paging to the database and only bulk-load {@code application_data}
+ * payloads for the page of results returned to the caller.
+ *
+ * <p>Each event handler reads from {@link ApplicationDataStore} at most once per event. There is no
+ * N+1 risk: the query path reads {@code application_data} only for the page, not for every
+ * candidate row.
+ */
+@Component
+@Namespace("application-list-index-projection")
+public class ApplicationListIndexProjection {
+
+  private final ApplicationListIndexReadRepository listIndexRepository;
+  private final ApplicationDataStore applicationDataStore;
+
+  /** Constructs the projection with its repository and data store. */
+  public ApplicationListIndexProjection(
+      ApplicationListIndexReadRepository listIndexRepository,
+      ApplicationDataStore applicationDataStore) {
+    this.listIndexRepository = listIndexRepository;
+    this.applicationDataStore = applicationDataStore;
+  }
+
+  /**
+   * Inserts the initial index row from an Application's creation event.
+   *
+   * <p>Reads the referenced {@code application_data} version once to populate PII filter columns
+   * and filter fields that are not carried on the thin event.
+   */
+  @EventHandler
+  public void on(ApplicationCreatedEvent event, EventMessage message) {
+    ApplicationDataPayload data =
+        applicationDataStore.get(event.applicationId(), event.applicationDataVersion());
+
+    ApplicationIndividual client = primaryClient(data);
+
+    listIndexRepository.save(
+        ApplicationListIndexReadModel.builder()
+            .applicationId(event.applicationId())
+            .status(event.status())
+            .laaReference(data.laaReference())
+            .caseworkerId(null)
+            .matterType(data.matterType() == null ? null : data.matterType().name())
+            .isAutoGranted(null)
+            .submittedAt(data.submittedAt())
+            .leadApplicationId(event.leadApplicationId())
+            .clientFirstName(client != null ? client.firstName() : null)
+            .clientLastName(client != null ? client.lastName() : null)
+            .clientDateOfBirth(client != null ? client.dateOfBirth() : null)
+            .streamVersion(0L)
+            .projectionPosition(message.identifier().hashCode())
+            .build());
+  }
+
+  /** Updates the {@code lead_application_id} when an application is linked to a group. */
+  @EventHandler
+  public void on(ApplicationLinkedEvent event, EventMessage message) {
+    listIndexRepository
+        .findById(event.applicationId())
+        .ifPresent(
+            row -> {
+              row.setLeadApplicationId(event.leadApplicationId());
+              row.setProjectionPosition(message.identifier().hashCode());
+              listIndexRepository.save(row);
+            });
+  }
+
+  /**
+   * Updates {@code status}, {@code is_auto_granted}, and {@code stream_version} when a decision is
+   * made.
+   */
+  @EventHandler
+  public void on(ApplicationDecisionMadeEvent event, EventMessage message) {
+    listIndexRepository
+        .findById(event.applicationId())
+        .ifPresent(
+            row -> {
+              row.setStatus(
+                  event.overallDecision() != null ? event.overallDecision() : row.getStatus());
+              row.setIsAutoGranted(event.autoGranted());
+              row.setStreamVersion(event.applicationVersion());
+              row.setProjectionPosition(message.identifier().hashCode());
+              listIndexRepository.save(row);
+            });
+  }
+
+  /** Updates {@code caseworker_id} and {@code stream_version} when a caseworker is assigned. */
+  @EventHandler
+  public void on(ApplicationAssignedToCaseworkerEvent event, EventMessage message) {
+    listIndexRepository
+        .findById(event.applicationId())
+        .ifPresent(
+            row -> {
+              row.setCaseworkerId(event.caseworkerId());
+              row.setStreamVersion(event.applicationVersion());
+              row.setProjectionPosition(message.identifier().hashCode());
+              listIndexRepository.save(row);
+            });
+  }
+
+  /** Clears {@code caseworker_id} and updates {@code stream_version} on unassignment. */
+  @EventHandler
+  public void on(ApplicationUnassignedFromCaseworkerEvent event, EventMessage message) {
+    listIndexRepository
+        .findById(event.applicationId())
+        .ifPresent(
+            row -> {
+              row.setCaseworkerId(null);
+              row.setStreamVersion(event.applicationVersion());
+              row.setProjectionPosition(message.identifier().hashCode());
+              listIndexRepository.save(row);
+            });
+  }
+
+  /**
+   * Updates {@code projection_position} when a note is created.
+   *
+   * <p>Note creation does not change any filter or sort field on the index, so only the position
+   * bookkeeping column is updated.
+   */
+  @EventHandler
+  public void on(NoteCreatedEvent event, EventMessage message) {
+    listIndexRepository
+        .findById(event.applicationId())
+        .ifPresent(
+            row -> {
+              row.setProjectionPosition(message.identifier().hashCode());
+              listIndexRepository.save(row);
+            });
+  }
+
+  /** Clears the disposable index table before replay. */
+  @ResetHandler
+  public void reset() {
+    listIndexRepository.deleteAllInBatch();
+  }
+
+  private ApplicationIndividual primaryClient(ApplicationDataPayload data) {
+    List<ApplicationIndividual> individuals = data.individuals();
+    if (individuals == null) {
+      return null;
+    }
+    return individuals.stream().filter(i -> "CLIENT".equals(i.type())).findFirst().orElse(null);
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexReadModel.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexReadModel.java
@@ -1,0 +1,81 @@
+package uk.gov.justice.laa.dstew.access.query.application.listindex;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Replayable list-index read model used exclusively for filtering, sorting, counting, and paging
+ * the {@code GET /applications} endpoint.
+ *
+ * <p>All columns are persisted — there are no {@code @Transient} fields. The minimum PII needed for
+ * client-name and date-of-birth filters ({@code client_first_name}, {@code client_last_name},
+ * {@code client_date_of_birth}) is stored here so filters can be pushed entirely to the database.
+ * Rich response-only fields (proceedings, certificate, application content, etc.) are not
+ * duplicated into this table; they are bulk-loaded from {@code application_data} for the result
+ * page only, after paging has been applied.
+ */
+@Entity
+@Table(name = "application_list_index")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplicationListIndexReadModel {
+
+  @Id
+  @Column(name = "application_id")
+  private UUID applicationId;
+
+  @Column(name = "status", nullable = false)
+  private String status;
+
+  @Column(name = "laa_reference")
+  private String laaReference;
+
+  @Column(name = "caseworker_id")
+  private UUID caseworkerId;
+
+  @Column(name = "matter_type")
+  private String matterType;
+
+  @Column(name = "is_auto_granted")
+  private Boolean isAutoGranted;
+
+  @Column(name = "submitted_at")
+  private Instant submittedAt;
+
+  @Column(name = "lead_application_id")
+  private UUID leadApplicationId;
+
+  @Column(name = "client_first_name")
+  private String clientFirstName;
+
+  @Column(name = "client_last_name")
+  private String clientLastName;
+
+  @Column(name = "client_date_of_birth")
+  private LocalDate clientDateOfBirth;
+
+  /**
+   * The application-domain version at the time this row was last written. Used as an optimistic
+   * concurrency guard during projection updates.
+   */
+  @Column(name = "stream_version", nullable = false)
+  private long streamVersion;
+
+  /**
+   * The Axon global event index at which this row was last written. Used to measure projection lag
+   * relative to {@code domain_event_entry.global_index}.
+   */
+  @Column(name = "projection_position", nullable = false)
+  private long projectionPosition;
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexReadRepository.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexReadRepository.java
@@ -1,0 +1,10 @@
+package uk.gov.justice.laa.dstew.access.query.application.listindex;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+/** Persistence interface for the {@code application_list_index} projection. */
+public interface ApplicationListIndexReadRepository
+    extends JpaRepository<ApplicationListIndexReadModel, UUID>,
+        JpaSpecificationExecutor<ApplicationListIndexReadModel> {}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexSpecification.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexSpecification.java
@@ -1,0 +1,58 @@
+package uk.gov.justice.laa.dstew.access.query.application.listindex;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.justice.laa.dstew.access.query.application.FindAllApplicationsQuery;
+
+/**
+ * Builds a JPA {@link Specification} from a {@link FindAllApplicationsQuery}.
+ *
+ * <p>All non-null filter fields produce a database predicate so that filtering and counting happen
+ * entirely in PostgreSQL before any rows are returned to the application. Client-name predicates
+ * use {@code lower()} to match the functional indexes created by the V15 migration.
+ */
+public final class ApplicationListIndexSpecification {
+
+  private ApplicationListIndexSpecification() {}
+
+  /** Returns a {@link Specification} that applies every non-null filter in the query. */
+  public static Specification<ApplicationListIndexReadModel> from(FindAllApplicationsQuery query) {
+    return (root, criteriaQuery, cb) -> {
+      List<Predicate> predicates = new ArrayList<>();
+
+      if (query.status() != null) {
+        predicates.add(cb.equal(root.get("status"), query.status()));
+      }
+      if (query.laaReference() != null) {
+        predicates.add(cb.equal(root.get("laaReference"), query.laaReference()));
+      }
+      if (query.matterType() != null) {
+        predicates.add(cb.equal(root.get("matterType"), query.matterType()));
+      }
+      if (query.clientFirstName() != null) {
+        predicates.add(likeIgnoreCase(cb, root, "clientFirstName", query.clientFirstName()));
+      }
+      if (query.clientLastName() != null) {
+        predicates.add(likeIgnoreCase(cb, root, "clientLastName", query.clientLastName()));
+      }
+      if (query.clientDateOfBirth() != null) {
+        predicates.add(cb.equal(root.get("clientDateOfBirth"), query.clientDateOfBirth()));
+      }
+
+      return cb.and(predicates.toArray(new Predicate[0]));
+    };
+  }
+
+  /**
+   * Builds a case-insensitive prefix predicate matching the {@code lower(column)} functional
+   * indexes created in the V15 migration.
+   */
+  private static Predicate likeIgnoreCase(
+      CriteriaBuilder cb, Root<ApplicationListIndexReadModel> root, String field, String value) {
+    return cb.like(cb.lower(root.get(field)), value.toLowerCase() + "%");
+  }
+}

--- a/data-access-service-axon/src/main/resources/db/migration/V3__create_application_list_index.sql
+++ b/data-access-service-axon/src/main/resources/db/migration/V3__create_application_list_index.sql
@@ -1,0 +1,37 @@
+CREATE TABLE application_list_index (
+    application_id       UUID         NOT NULL,
+    status               VARCHAR(255) NOT NULL,
+    laa_reference        VARCHAR(255),
+    caseworker_id        UUID,
+    matter_type          VARCHAR(255),
+    is_auto_granted      BOOLEAN,
+    submitted_at         TIMESTAMPTZ,
+    lead_application_id  UUID,
+    client_first_name    VARCHAR(255),
+    client_last_name     VARCHAR(255),
+    client_date_of_birth DATE,
+    stream_version       BIGINT       NOT NULL DEFAULT 0,
+    projection_position  BIGINT       NOT NULL DEFAULT 0,
+    PRIMARY KEY (application_id)
+);
+
+-- Equality filter indexes
+CREATE INDEX idx_ali_status        ON application_list_index (status);
+CREATE INDEX idx_ali_matter_type   ON application_list_index (matter_type);
+CREATE INDEX idx_ali_laa_reference ON application_list_index (laa_reference);
+CREATE INDEX idx_ali_caseworker    ON application_list_index (caseworker_id);
+
+-- Case-insensitive client name filter indexes
+CREATE INDEX idx_ali_client_last_name  ON application_list_index (lower(client_last_name));
+CREATE INDEX idx_ali_client_first_name ON application_list_index (lower(client_first_name));
+
+-- Exact DOB equality filter
+CREATE INDEX idx_ali_client_dob ON application_list_index (client_date_of_birth);
+
+-- Sort index (most common: newest first)
+CREATE INDEX idx_ali_submitted_at ON application_list_index (submitted_at DESC NULLS LAST);
+
+-- Composite for the caseworker worklist: filter + sort in a single scan
+CREATE INDEX idx_ali_caseworker_submitted
+    ON application_list_index (caseworker_id, submitted_at DESC NULLS LAST);
+

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
@@ -11,6 +11,8 @@ import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreatedEventF
 import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreatedEventFixture.applicationCreationDetails;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
@@ -18,15 +20,21 @@ import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationCreatedEvent;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationLinkedEvent;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationAssignedToCaseworkerEvent;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationUnassignedFromCaseworkerEvent;
+import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataId;
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataPayload;
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataStore;
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationNote;
 import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadRepository;
+import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexReadModel;
+import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexReadRepository;
 
 class ApplicationProjectionTest {
 
@@ -34,6 +42,7 @@ class ApplicationProjectionTest {
   private LinkedApplicationGroupReadRepository groupReadRepository;
   private QueryUpdateEmitter queryUpdateEmitter;
   private ApplicationDataStore applicationDataStore;
+  private ApplicationListIndexReadRepository listIndexRepository;
   private ApplicationProjection projection;
 
   @BeforeEach
@@ -42,13 +51,17 @@ class ApplicationProjectionTest {
     groupReadRepository = mock(LinkedApplicationGroupReadRepository.class);
     queryUpdateEmitter = mock(QueryUpdateEmitter.class);
     applicationDataStore = mock(ApplicationDataStore.class);
+    listIndexRepository = mock(ApplicationListIndexReadRepository.class);
     when(applicationDataStore.get(any(), anyLong()))
         .thenAnswer(
             invocation ->
                 ApplicationDataPayload.from(applicationCreationDetails(invocation.getArgument(0))));
     projection =
         new ApplicationProjection(
-            applicationReadRepository, groupReadRepository, applicationDataStore);
+            applicationReadRepository,
+            groupReadRepository,
+            applicationDataStore,
+            listIndexRepository);
   }
 
   @Test
@@ -63,7 +76,6 @@ class ApplicationProjectionTest {
 
     InOrder order = inOrder(applicationReadRepository, queryUpdateEmitter);
     order.verify(applicationReadRepository).save(any());
-    // The default emit(Class, Predicate, U) is called with ApplicationReadModel as U
     order
         .verify(queryUpdateEmitter)
         .emit(any(Class.class), any(Predicate.class), any(ApplicationReadModel.class));
@@ -77,7 +89,6 @@ class ApplicationProjectionTest {
     ApplicationCreatedEvent event = applicationCreatedEvent(applicationId);
 
     final Predicate<?>[] capturedPredicate = new Predicate[1];
-    // Stub the default emit(Class, Predicate, U) overload by matching ApplicationReadModel
     org.mockito.Mockito.doAnswer(
             inv -> {
               capturedPredicate[0] = (Predicate<?>) inv.getArgument(1);
@@ -255,5 +266,57 @@ class ApplicationProjectionTest {
 
     assertThat(result).isNotNull();
     assertThat(result.notes()).isEmpty();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void givenIndexReturnsPage_whenFindAllApplicationsQuery_thenBatchLoadsBothSourcesAndAssembles() {
+    UUID appId = UUID.randomUUID();
+    ApplicationListIndexReadModel indexRow =
+        ApplicationListIndexReadModel.builder().applicationId(appId).build();
+
+    when(listIndexRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(indexRow)));
+
+    ApplicationReadModel state =
+        ApplicationReadModel.builder()
+            .applicationId(appId)
+            .applicationDataVersion(0L)
+            .modifiedAt(Instant.EPOCH)
+            .build();
+    when(applicationReadRepository.findAllById(List.of(appId))).thenReturn(List.of(state));
+
+    ApplicationDataId dataId = new ApplicationDataId(appId, 0L);
+    ApplicationDataPayload payload = ApplicationDataPayload.from(applicationCreationDetails(appId));
+    when(applicationDataStore.getAll(List.of(dataId))).thenReturn(Map.of(dataId, payload));
+
+    when(groupReadRepository.findAllByLeadApplicationIdIn(any())).thenReturn(List.of());
+
+    FindAllApplicationsResult result =
+        projection.handle(
+            new FindAllApplicationsQuery(null, null, null, null, null, null, null, null, 1, 20));
+
+    assertThat(result.applications()).hasSize(1);
+    assertThat(result.applications().getFirst().getApplicationId()).isEqualTo(appId);
+    assertThat(result.totalElements()).isEqualTo(1L);
+
+    // Verify batch loads — not per-row findById calls
+    verify(applicationReadRepository).findAllById(List.of(appId));
+    verify(applicationDataStore).getAll(List.of(dataId));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void givenEmptyIndexPage_whenFindAllApplicationsQuery_thenReturnsEmptyResult() {
+    when(listIndexRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+    when(groupReadRepository.findAllByLeadApplicationIdIn(any())).thenReturn(List.of());
+
+    FindAllApplicationsResult result =
+        projection.handle(
+            new FindAllApplicationsQuery(null, null, null, null, null, null, null, null, 1, 20));
+
+    assertThat(result.applications()).isEmpty();
+    assertThat(result.totalElements()).isZero();
   }
 }

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexProjectionTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexProjectionTest.java
@@ -1,0 +1,305 @@
+package uk.gov.justice.laa.dstew.access.query.application.listindex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreatedEventFixture.applicationCreatedEvent;
+import static uk.gov.justice.laa.dstew.access.testutils.ApplicationCreatedEventFixture.applicationCreationDetails;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.axonframework.messaging.core.MessageType;
+import org.axonframework.messaging.eventhandling.EventMessage;
+import org.axonframework.messaging.eventhandling.GenericEventMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationIndividual;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationLinkedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationAssignedToCaseworkerEvent;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationUnassignedFromCaseworkerEvent;
+import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataPayload;
+import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataStore;
+import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
+import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
+
+class ApplicationListIndexProjectionTest {
+
+  private ApplicationListIndexReadRepository listIndexRepository;
+  private ApplicationDataStore applicationDataStore;
+  private ApplicationListIndexProjection projection;
+
+  @BeforeEach
+  void setUp() {
+    listIndexRepository = mock(ApplicationListIndexReadRepository.class);
+    applicationDataStore = mock(ApplicationDataStore.class);
+    projection = new ApplicationListIndexProjection(listIndexRepository, applicationDataStore);
+  }
+
+  private static EventMessage anyMessage() {
+    return new GenericEventMessage(
+        "test-id", new MessageType(String.class), "test", Map.of(), Instant.now());
+  }
+
+  // -------------------------------------------------------------------------
+  // ApplicationCreatedEvent
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenCreatedEvent_whenHandled_thenInsertsIndexRowWithStatusAndLaaReference() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationCreatedEvent event = applicationCreatedEvent(applicationId);
+    ApplicationDataPayload payload =
+        ApplicationDataPayload.from(applicationCreationDetails(applicationId));
+    when(applicationDataStore.get(applicationId, event.applicationDataVersion()))
+        .thenReturn(payload);
+
+    projection.on(event, anyMessage());
+
+    ArgumentCaptor<ApplicationListIndexReadModel> captor =
+        ArgumentCaptor.forClass(ApplicationListIndexReadModel.class);
+    verify(listIndexRepository).save(captor.capture());
+    ApplicationListIndexReadModel saved = captor.getValue();
+
+    assertThat(saved.getApplicationId()).isEqualTo(applicationId);
+    assertThat(saved.getStatus()).isEqualTo(event.status());
+    assertThat(saved.getLaaReference()).isEqualTo(payload.laaReference());
+    assertThat(saved.getCaseworkerId()).isNull();
+    assertThat(saved.getStreamVersion()).isZero();
+  }
+
+  @Test
+  void givenCreatedEventWithClientIndividual_whenHandled_thenPopulatesPiiColumns() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationCreatedEvent event = applicationCreatedEvent(applicationId);
+
+    ApplicationIndividual client =
+        new ApplicationIndividual(
+            UUID.randomUUID(), "Jane", "Smith", LocalDate.of(1990, 6, 15), null, "CLIENT");
+    ApplicationDataPayload basePayload =
+        ApplicationDataPayload.from(applicationCreationDetails(applicationId));
+    // Build a payload with the client individual via the public constructor fields
+    ApplicationDataPayload payloadWithClient =
+        new ApplicationDataPayload(
+            basePayload.laaReference(),
+            basePayload.applicationContent(),
+            List.of(client),
+            basePayload.applyApplicationId(),
+            basePayload.submittedAt(),
+            basePayload.officeCode(),
+            basePayload.usedDelegatedFunctions(),
+            basePayload.categoryOfLaw(),
+            basePayload.matterType(),
+            basePayload.proceedings(),
+            basePayload.serialisedRequest(),
+            basePayload.overallDecision(),
+            basePayload.autoGranted(),
+            basePayload.meritsDecisions(),
+            basePayload.certificate(),
+            basePayload.decisionSerialisedRequest(),
+            basePayload.decisionEventDescription(),
+            basePayload.assignmentEventDescription(),
+            basePayload.notes());
+
+    when(applicationDataStore.get(applicationId, event.applicationDataVersion()))
+        .thenReturn(payloadWithClient);
+
+    projection.on(event, anyMessage());
+
+    ArgumentCaptor<ApplicationListIndexReadModel> captor =
+        ArgumentCaptor.forClass(ApplicationListIndexReadModel.class);
+    verify(listIndexRepository).save(captor.capture());
+    ApplicationListIndexReadModel saved = captor.getValue();
+
+    assertThat(saved.getClientFirstName()).isEqualTo("Jane");
+    assertThat(saved.getClientLastName()).isEqualTo("Smith");
+    assertThat(saved.getClientDateOfBirth()).isEqualTo(LocalDate.of(1990, 6, 15));
+  }
+
+  @Test
+  void givenCreatedEventWithNoIndividuals_whenHandled_thenPiiColumnsAreNull() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationCreatedEvent event = applicationCreatedEvent(applicationId);
+    ApplicationDataPayload payload =
+        ApplicationDataPayload.from(applicationCreationDetails(applicationId));
+    when(applicationDataStore.get(applicationId, event.applicationDataVersion()))
+        .thenReturn(payload);
+
+    projection.on(event, anyMessage());
+
+    ArgumentCaptor<ApplicationListIndexReadModel> captor =
+        ArgumentCaptor.forClass(ApplicationListIndexReadModel.class);
+    verify(listIndexRepository).save(captor.capture());
+    ApplicationListIndexReadModel saved = captor.getValue();
+
+    assertThat(saved.getClientFirstName()).isNull();
+    assertThat(saved.getClientLastName()).isNull();
+    assertThat(saved.getClientDateOfBirth()).isNull();
+  }
+
+  // -------------------------------------------------------------------------
+  // ApplicationLinkedEvent
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenLinkedEvent_whenHandled_thenUpdatesLeadApplicationId() {
+    UUID applicationId = UUID.randomUUID();
+    UUID leadId = UUID.randomUUID();
+    ApplicationListIndexReadModel existing =
+        ApplicationListIndexReadModel.builder().applicationId(applicationId).build();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+
+    projection.on(new ApplicationLinkedEvent(applicationId, leadId, Instant.now()), anyMessage());
+
+    assertThat(existing.getLeadApplicationId()).isEqualTo(leadId);
+    verify(listIndexRepository).save(existing);
+  }
+
+  @Test
+  void givenLinkedEventForUnknownApplication_whenHandled_thenDoesNothing() {
+    UUID applicationId = UUID.randomUUID();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.empty());
+
+    projection.on(
+        new ApplicationLinkedEvent(applicationId, UUID.randomUUID(), Instant.now()), anyMessage());
+
+    verify(listIndexRepository, never()).save(any());
+  }
+
+  // -------------------------------------------------------------------------
+  // ApplicationDecisionMadeEvent
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenDecisionEvent_whenHandled_thenUpdatesStatusAndAutoGrantedAndStreamVersion() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationListIndexReadModel existing =
+        ApplicationListIndexReadModel.builder()
+            .applicationId(applicationId)
+            .status("APPLICATION_SUBMITTED")
+            .streamVersion(0L)
+            .build();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+
+    projection.on(
+        new ApplicationDecisionMadeEvent(applicationId, 3L, 4L, "GRANTED", true, Instant.now()),
+        anyMessage());
+
+    assertThat(existing.getStatus()).isEqualTo("GRANTED");
+    assertThat(existing.getIsAutoGranted()).isTrue();
+    assertThat(existing.getStreamVersion()).isEqualTo(3L);
+    verify(listIndexRepository).save(existing);
+  }
+
+  @Test
+  void givenDecisionEventWithNullDecision_whenHandled_thenKeepsExistingStatus() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationListIndexReadModel existing =
+        ApplicationListIndexReadModel.builder()
+            .applicationId(applicationId)
+            .status("APPLICATION_SUBMITTED")
+            .streamVersion(0L)
+            .build();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+
+    projection.on(
+        new ApplicationDecisionMadeEvent(applicationId, 3L, 4L, null, false, Instant.now()),
+        anyMessage());
+
+    assertThat(existing.getStatus()).isEqualTo("APPLICATION_SUBMITTED");
+    verify(listIndexRepository).save(existing);
+  }
+
+  // -------------------------------------------------------------------------
+  // ApplicationAssignedToCaseworkerEvent
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenAssignmentEvent_whenHandled_thenSetsCaseworkerIdAndStreamVersion() {
+    UUID applicationId = UUID.randomUUID();
+    UUID caseworkerId = UUID.randomUUID();
+    ApplicationListIndexReadModel existing =
+        ApplicationListIndexReadModel.builder()
+            .applicationId(applicationId)
+            .streamVersion(0L)
+            .build();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+
+    projection.on(
+        new ApplicationAssignedToCaseworkerEvent(
+            applicationId, 1L, 2L, caseworkerId, Instant.now()),
+        anyMessage());
+
+    assertThat(existing.getCaseworkerId()).isEqualTo(caseworkerId);
+    assertThat(existing.getStreamVersion()).isEqualTo(1L);
+    verify(listIndexRepository).save(existing);
+  }
+
+  // -------------------------------------------------------------------------
+  // ApplicationUnassignedFromCaseworkerEvent
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenUnassignmentEvent_whenHandled_thenClearsCaseworkerIdAndUpdatesStreamVersion() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationListIndexReadModel existing =
+        ApplicationListIndexReadModel.builder()
+            .applicationId(applicationId)
+            .caseworkerId(UUID.randomUUID())
+            .streamVersion(1L)
+            .build();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+
+    projection.on(
+        new ApplicationUnassignedFromCaseworkerEvent(applicationId, 2L, 3L, Instant.now()),
+        anyMessage());
+
+    assertThat(existing.getCaseworkerId()).isNull();
+    assertThat(existing.getStreamVersion()).isEqualTo(2L);
+    verify(listIndexRepository).save(existing);
+  }
+
+  // -------------------------------------------------------------------------
+  // NoteCreatedEvent
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenNoteCreatedEvent_whenHandled_thenSavesRowWithoutChangingFilterFields() {
+    UUID applicationId = UUID.randomUUID();
+    ApplicationListIndexReadModel existing =
+        ApplicationListIndexReadModel.builder()
+            .applicationId(applicationId)
+            .status("APPLICATION_SUBMITTED")
+            .clientFirstName("Jane")
+            .streamVersion(1L)
+            .build();
+    when(listIndexRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+
+    projection.on(new NoteCreatedEvent(applicationId, 2L, Instant.now()), anyMessage());
+
+    // Filter fields must not be modified
+    assertThat(existing.getStatus()).isEqualTo("APPLICATION_SUBMITTED");
+    assertThat(existing.getClientFirstName()).isEqualTo("Jane");
+    assertThat(existing.getStreamVersion()).isEqualTo(1L);
+    verify(listIndexRepository).save(existing);
+  }
+
+  // -------------------------------------------------------------------------
+  // Reset
+  // -------------------------------------------------------------------------
+
+  @Test
+  void givenResetCalled_whenHandled_thenDeletesAllIndexRows() {
+    projection.reset();
+
+    verify(listIndexRepository).deleteAllInBatch();
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexSpecificationTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/listindex/ApplicationListIndexSpecificationTest.java
@@ -1,0 +1,157 @@
+package uk.gov.justice.laa.dstew.access.query.application.listindex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.time.LocalDate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.jpa.domain.Specification;
+import uk.gov.justice.laa.dstew.access.query.application.FindAllApplicationsQuery;
+
+class ApplicationListIndexSpecificationTest {
+
+  private Root<ApplicationListIndexReadModel> root;
+  private CriteriaQuery<?> criteriaQuery;
+  private CriteriaBuilder cb;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    root = mock(Root.class);
+    criteriaQuery = mock(CriteriaQuery.class);
+    cb = mock(CriteriaBuilder.class);
+
+    // Stub root.get() to return a mock path for any field
+    Path mockPath = mock(Path.class);
+    when(root.get(any(String.class))).thenReturn(mockPath);
+
+    // Stub lower() for case-insensitive name predicates
+    Expression<String> loweredExpr = mock(Expression.class);
+    when(cb.lower(any())).thenReturn(loweredExpr);
+
+    // Stub individual predicate builders to return non-null predicates
+    Predicate equalPredicate = mock(Predicate.class);
+    Predicate likePredicate = mock(Predicate.class);
+    Predicate andPredicate = mock(Predicate.class);
+    when(cb.equal(any(), any())).thenReturn(equalPredicate);
+    when(cb.like(any(Expression.class), any(String.class))).thenReturn(likePredicate);
+    when(cb.and(any(Predicate[].class))).thenReturn(andPredicate);
+  }
+
+  @Test
+  void givenAllFiltersNull_whenBuilt_thenProducesAndWithNoPredicates() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(null, null, null, null, null, null, null, null, 1, 20);
+
+    Specification<ApplicationListIndexReadModel> spec =
+        ApplicationListIndexSpecification.from(query);
+    Predicate result = spec.toPredicate(root, criteriaQuery, cb);
+
+    assertThat(result).isNotNull();
+    // cb.and() was called with an empty array — the AND of zero predicates
+    org.mockito.Mockito.verify(cb).and(new Predicate[0]);
+  }
+
+  @Test
+  void givenStatusFilter_whenBuilt_thenAddsEqualPredicate() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(
+            "APPLICATION_SUBMITTED", null, null, null, null, null, null, null, 1, 20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    org.mockito.Mockito.verify(root).get("status");
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq("APPLICATION_SUBMITTED"));
+  }
+
+  @Test
+  void givenLaaReferenceFilter_whenBuilt_thenAddsEqualPredicate() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(null, "LAA-123", null, null, null, null, null, null, 1, 20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    org.mockito.Mockito.verify(root).get("laaReference");
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq("LAA-123"));
+  }
+
+  @Test
+  void givenMatterTypeFilter_whenBuilt_thenAddsEqualPredicate() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(null, null, "MEDIATION", null, null, null, null, null, 1, 20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    org.mockito.Mockito.verify(root).get("matterType");
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq("MEDIATION"));
+  }
+
+  @Test
+  void givenClientFirstNameFilter_whenBuilt_thenAddsLowercaseLikePredicate() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(null, null, null, "Jane", null, null, null, null, 1, 20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    org.mockito.Mockito.verify(root).get("clientFirstName");
+    org.mockito.Mockito.verify(cb).lower(any());
+    org.mockito.Mockito.verify(cb).like(any(Expression.class), org.mockito.Mockito.eq("jane%"));
+  }
+
+  @Test
+  void givenClientLastNameFilter_whenBuilt_thenAddsLowercaseLikePredicate() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(null, null, null, null, "Smith", null, null, null, 1, 20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    org.mockito.Mockito.verify(root).get("clientLastName");
+    org.mockito.Mockito.verify(cb).lower(any());
+    org.mockito.Mockito.verify(cb).like(any(Expression.class), org.mockito.Mockito.eq("smith%"));
+  }
+
+  @Test
+  void givenClientDateOfBirthFilter_whenBuilt_thenAddsEqualPredicate() {
+    LocalDate dob = LocalDate.of(1990, 6, 15);
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(null, null, null, null, null, dob, null, null, 1, 20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    org.mockito.Mockito.verify(root).get("clientDateOfBirth");
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq(dob));
+  }
+
+  @Test
+  void givenMultipleFilters_whenBuilt_thenCombinesAllPredicatesIntoAnd() {
+    FindAllApplicationsQuery query =
+        new FindAllApplicationsQuery(
+            "APPLICATION_SUBMITTED",
+            "LAA-123",
+            "MEDIATION",
+            null,
+            "Smith",
+            null,
+            null,
+            null,
+            1,
+            20);
+
+    ApplicationListIndexSpecification.from(query).toPredicate(root, criteriaQuery, cb);
+
+    // Three filters: status, laaReference, matterType + clientLastName = 4 predicates
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq("APPLICATION_SUBMITTED"));
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq("LAA-123"));
+    org.mockito.Mockito.verify(cb).equal(any(), org.mockito.Mockito.eq("MEDIATION"));
+    org.mockito.Mockito.verify(cb).like(any(Expression.class), org.mockito.Mockito.eq("smith%"));
+  }
+}


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2084)

Adds a denormalised application_list_index table and projection so that the GetAllApplications endpoint can filter and paginate applications by client name, date of birth, status, and caseworker entirely at the database level.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
