### PR TITLE
feat: DSTEW-2077 - Introduce use-case wrappers for Axon command dispatch

### DIFF
--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcher.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcher.java
@@ -1,0 +1,62 @@
+package uk.gov.justice.laa.dstew.access.command;
+
+import java.sql.SQLException;
+import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+/**
+ * Wraps Axon's {@link CommandGateway} with a single retry on concurrent-write failures.
+ *
+ * <p>Retries once when a {@link ConcurrencyException}, {@link
+ * AppendEventsTransactionRejectedException}, or a unique-constraint {@link
+ * DataIntegrityViolationException} (SQL state {@code 23505}) is thrown. All other exceptions are
+ * propagated immediately.
+ */
+@Component
+public class RetryingCommandDispatcher {
+
+  private final CommandGateway commandGateway;
+
+  public RetryingCommandDispatcher(CommandGateway commandGateway) {
+    this.commandGateway = commandGateway;
+  }
+
+  /** Dispatches the command, retrying once on concurrent-write failures. */
+  public void dispatch(Object command) {
+    try {
+      commandGateway.sendAndWait(command);
+    } catch (RuntimeException first) {
+      if (!isRetryableConcurrentWrite(first)) {
+        throw first;
+      }
+      try {
+        commandGateway.sendAndWait(command);
+      } catch (RuntimeException retry) {
+        retry.addSuppressed(first);
+        throw retry;
+      }
+    }
+  }
+
+  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
+    return exception instanceof ConcurrencyException
+        || exception instanceof AppendEventsTransactionRejectedException
+        || exception instanceof DataIntegrityViolationException
+            && hasUniqueConstraintViolation(exception);
+  }
+
+  private boolean hasUniqueConstraintViolation(Throwable exception) {
+    Throwable cause = exception;
+    while (cause != null) {
+      if (cause instanceof SQLException sqlException
+          && "23505".equals(sqlException.getSQLState())) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcher.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcher.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class RetryingCommandDispatcher {
 
+  private static final String UNIQUE_CONSTRAINT_VIOLATION = "23505";
+
   private final CommandGateway commandGateway;
 
   public RetryingCommandDispatcher(CommandGateway commandGateway) {
@@ -52,7 +54,7 @@ public class RetryingCommandDispatcher {
     Throwable cause = exception;
     while (cause != null) {
       if (cause instanceof SQLException sqlException
-          && "23505".equals(sqlException.getSQLState())) {
+          && UNIQUE_CONSTRAINT_VIOLATION.equals(sqlException.getSQLState())) {
         return true;
       }
       cause = cause.getCause();

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCase.java
@@ -1,11 +1,7 @@
 package uk.gov.justice.laa.dstew.access.command.application;
 
-import java.sql.SQLException;
-import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
@@ -17,12 +13,12 @@ import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuer
 @Component
 public class CreateApplicationUseCase {
 
-  private final CommandGateway commandGateway;
+  private final RetryingCommandDispatcher dispatcher;
   private final SubscriptionProjectionGateway projectionGateway;
 
   public CreateApplicationUseCase(
-      CommandGateway commandGateway, SubscriptionProjectionGateway projectionGateway) {
-    this.commandGateway = commandGateway;
+      RetryingCommandDispatcher dispatcher, SubscriptionProjectionGateway projectionGateway) {
+    this.dispatcher = dispatcher;
     this.projectionGateway = projectionGateway;
   }
 
@@ -36,41 +32,6 @@ public class CreateApplicationUseCase {
     return projectionGateway.awaitProjection(
         new FindApplicationByIdQuery(command.applicationId()),
         ApplicationReadModel.class,
-        () -> dispatchWithRetry(command));
-  }
-
-  private void dispatchWithRetry(Object command) {
-    try {
-      commandGateway.sendAndWait(command);
-    } catch (RuntimeException first) {
-      if (!isRetryableConcurrentWrite(first)) {
-        throw first;
-      }
-      try {
-        commandGateway.sendAndWait(command);
-      } catch (RuntimeException retry) {
-        retry.addSuppressed(first);
-        throw retry;
-      }
-    }
-  }
-
-  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
-    return exception instanceof ConcurrencyException
-        || exception instanceof AppendEventsTransactionRejectedException
-        || exception instanceof DataIntegrityViolationException
-            && hasUniqueConstraintViolation(exception);
-  }
-
-  private boolean hasUniqueConstraintViolation(Throwable exception) {
-    Throwable cause = exception;
-    while (cause != null) {
-      if (cause instanceof SQLException sqlException
-          && "23505".equals(sqlException.getSQLState())) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
+        () -> dispatcher.dispatch(command));
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCase.java
@@ -1,0 +1,76 @@
+package uk.gov.justice.laa.dstew.access.command.application;
+
+import java.sql.SQLException;
+import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
+import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
+import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
+
+/**
+ * Dispatches a create-application command and waits for the projection to confirm the application
+ * is readable.
+ */
+@Component
+public class CreateApplicationUseCase {
+
+  private final CommandGateway commandGateway;
+  private final SubscriptionProjectionGateway projectionGateway;
+
+  public CreateApplicationUseCase(
+      CommandGateway commandGateway, SubscriptionProjectionGateway projectionGateway) {
+    this.commandGateway = commandGateway;
+    this.projectionGateway = projectionGateway;
+  }
+
+  /**
+   * Dispatches the command and waits for the projection to become readable.
+   *
+   * @return {@code true} when the projection confirms the application within the configured
+   *     timeout; {@code false} on timeout — the command has still committed.
+   */
+  public boolean execute(CreateApplicationCommand command) {
+    return projectionGateway.awaitProjection(
+        new FindApplicationByIdQuery(command.applicationId()),
+        ApplicationReadModel.class,
+        () -> dispatchWithRetry(command));
+  }
+
+  private void dispatchWithRetry(Object command) {
+    try {
+      commandGateway.sendAndWait(command);
+    } catch (RuntimeException first) {
+      if (!isRetryableConcurrentWrite(first)) {
+        throw first;
+      }
+      try {
+        commandGateway.sendAndWait(command);
+      } catch (RuntimeException retry) {
+        retry.addSuppressed(first);
+        throw retry;
+      }
+    }
+  }
+
+  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
+    return exception instanceof ConcurrencyException
+        || exception instanceof AppendEventsTransactionRejectedException
+        || exception instanceof DataIntegrityViolationException
+            && hasUniqueConstraintViolation(exception);
+  }
+
+  private boolean hasUniqueConstraintViolation(Throwable exception) {
+    Throwable cause = exception;
+    while (cause != null) {
+      if (cause instanceof SQLException sqlException
+          && "23505".equals(sqlException.getSQLState())) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCase.java
@@ -10,13 +10,13 @@ import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 
 /** Validates and dispatches a single Application assignment command. */
 @Service
-public class AssignCaseworkerService {
+public class AssignCaseworkerUseCase {
 
   private final CaseworkerRepository caseworkerRepository;
   private final CommandGateway commandGateway;
 
   /** Creates the assignment coordinator with its directory and command gateway. */
-  public AssignCaseworkerService(
+  public AssignCaseworkerUseCase(
       CaseworkerRepository caseworkerRepository, CommandGateway commandGateway) {
     this.caseworkerRepository = caseworkerRepository;
     this.commandGateway = commandGateway;

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCase.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.laa.dstew.access.command.application.assignment;
+
+import java.sql.SQLException;
+import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+/** Dispatches an unassign-caseworker command with a single retry on concurrent-write failures. */
+@Component
+public class UnassignCaseworkerUseCase {
+
+  private final CommandGateway commandGateway;
+
+  public UnassignCaseworkerUseCase(CommandGateway commandGateway) {
+    this.commandGateway = commandGateway;
+  }
+
+  /** Dispatches the command to the application aggregate. */
+  public void execute(UnassignCaseworkerFromApplicationCommand command) {
+    try {
+      commandGateway.sendAndWait(command);
+    } catch (RuntimeException first) {
+      if (!isRetryableConcurrentWrite(first)) {
+        throw first;
+      }
+      try {
+        commandGateway.sendAndWait(command);
+      } catch (RuntimeException retry) {
+        retry.addSuppressed(first);
+        throw retry;
+      }
+    }
+  }
+
+  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
+    return exception instanceof ConcurrencyException
+        || exception instanceof AppendEventsTransactionRejectedException
+        || exception instanceof DataIntegrityViolationException
+            && hasUniqueConstraintViolation(exception);
+  }
+
+  private boolean hasUniqueConstraintViolation(Throwable exception) {
+    Throwable cause = exception;
+    while (cause != null) {
+      if (cause instanceof SQLException sqlException
+          && "23505".equals(sqlException.getSQLState())) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCase.java
@@ -1,55 +1,20 @@
 package uk.gov.justice.laa.dstew.access.command.application.assignment;
 
-import java.sql.SQLException;
-import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 
 /** Dispatches an unassign-caseworker command with a single retry on concurrent-write failures. */
 @Component
 public class UnassignCaseworkerUseCase {
 
-  private final CommandGateway commandGateway;
+  private final RetryingCommandDispatcher dispatcher;
 
-  public UnassignCaseworkerUseCase(CommandGateway commandGateway) {
-    this.commandGateway = commandGateway;
+  public UnassignCaseworkerUseCase(RetryingCommandDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
   }
 
   /** Dispatches the command to the application aggregate. */
   public void execute(UnassignCaseworkerFromApplicationCommand command) {
-    try {
-      commandGateway.sendAndWait(command);
-    } catch (RuntimeException first) {
-      if (!isRetryableConcurrentWrite(first)) {
-        throw first;
-      }
-      try {
-        commandGateway.sendAndWait(command);
-      } catch (RuntimeException retry) {
-        retry.addSuppressed(first);
-        throw retry;
-      }
-    }
-  }
-
-  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
-    return exception instanceof ConcurrencyException
-        || exception instanceof AppendEventsTransactionRejectedException
-        || exception instanceof DataIntegrityViolationException
-            && hasUniqueConstraintViolation(exception);
-  }
-
-  private boolean hasUniqueConstraintViolation(Throwable exception) {
-    Throwable cause = exception;
-    while (cause != null) {
-      if (cause instanceof SQLException sqlException
-          && "23505".equals(sqlException.getSQLState())) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
+    dispatcher.dispatch(command);
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCase.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.laa.dstew.access.command.application.decision;
+
+import java.sql.SQLException;
+import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+/** Dispatches a make-decision command with a single retry on concurrent-write failures. */
+@Component
+public class MakeApplicationDecisionUseCase {
+
+  private final CommandGateway commandGateway;
+
+  public MakeApplicationDecisionUseCase(CommandGateway commandGateway) {
+    this.commandGateway = commandGateway;
+  }
+
+  /** Dispatches the command to the application aggregate. */
+  public void execute(MakeApplicationDecisionCommand command) {
+    try {
+      commandGateway.sendAndWait(command);
+    } catch (RuntimeException first) {
+      if (!isRetryableConcurrentWrite(first)) {
+        throw first;
+      }
+      try {
+        commandGateway.sendAndWait(command);
+      } catch (RuntimeException retry) {
+        retry.addSuppressed(first);
+        throw retry;
+      }
+    }
+  }
+
+  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
+    return exception instanceof ConcurrencyException
+        || exception instanceof AppendEventsTransactionRejectedException
+        || exception instanceof DataIntegrityViolationException
+            && hasUniqueConstraintViolation(exception);
+  }
+
+  private boolean hasUniqueConstraintViolation(Throwable exception) {
+    Throwable cause = exception;
+    while (cause != null) {
+      if (cause instanceof SQLException sqlException
+          && "23505".equals(sqlException.getSQLState())) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCase.java
@@ -1,55 +1,20 @@
 package uk.gov.justice.laa.dstew.access.command.application.decision;
 
-import java.sql.SQLException;
-import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 
 /** Dispatches a make-decision command with a single retry on concurrent-write failures. */
 @Component
 public class MakeApplicationDecisionUseCase {
 
-  private final CommandGateway commandGateway;
+  private final RetryingCommandDispatcher dispatcher;
 
-  public MakeApplicationDecisionUseCase(CommandGateway commandGateway) {
-    this.commandGateway = commandGateway;
+  public MakeApplicationDecisionUseCase(RetryingCommandDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
   }
 
   /** Dispatches the command to the application aggregate. */
   public void execute(MakeApplicationDecisionCommand command) {
-    try {
-      commandGateway.sendAndWait(command);
-    } catch (RuntimeException first) {
-      if (!isRetryableConcurrentWrite(first)) {
-        throw first;
-      }
-      try {
-        commandGateway.sendAndWait(command);
-      } catch (RuntimeException retry) {
-        retry.addSuppressed(first);
-        throw retry;
-      }
-    }
-  }
-
-  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
-    return exception instanceof ConcurrencyException
-        || exception instanceof AppendEventsTransactionRejectedException
-        || exception instanceof DataIntegrityViolationException
-            && hasUniqueConstraintViolation(exception);
-  }
-
-  private boolean hasUniqueConstraintViolation(Throwable exception) {
-    Throwable cause = exception;
-    while (cause != null) {
-      if (cause instanceof SQLException sqlException
-          && "23505".equals(sqlException.getSQLState())) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
+    dispatcher.dispatch(command);
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCase.java
@@ -1,0 +1,55 @@
+package uk.gov.justice.laa.dstew.access.command.application.note;
+
+import java.sql.SQLException;
+import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+/** Dispatches a create-note command with a single retry on concurrent-write failures. */
+@Component
+public class CreateNoteUseCase {
+
+  private final CommandGateway commandGateway;
+
+  public CreateNoteUseCase(CommandGateway commandGateway) {
+    this.commandGateway = commandGateway;
+  }
+
+  /** Dispatches the command to the application aggregate. */
+  public void execute(CreateNoteCommand command) {
+    try {
+      commandGateway.sendAndWait(command);
+    } catch (RuntimeException first) {
+      if (!isRetryableConcurrentWrite(first)) {
+        throw first;
+      }
+      try {
+        commandGateway.sendAndWait(command);
+      } catch (RuntimeException retry) {
+        retry.addSuppressed(first);
+        throw retry;
+      }
+    }
+  }
+
+  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
+    return exception instanceof ConcurrencyException
+        || exception instanceof AppendEventsTransactionRejectedException
+        || exception instanceof DataIntegrityViolationException
+            && hasUniqueConstraintViolation(exception);
+  }
+
+  private boolean hasUniqueConstraintViolation(Throwable exception) {
+    Throwable cause = exception;
+    while (cause != null) {
+      if (cause instanceof SQLException sqlException
+          && "23505".equals(sqlException.getSQLState())) {
+        return true;
+      }
+      cause = cause.getCause();
+    }
+    return false;
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCase.java
@@ -1,55 +1,20 @@
 package uk.gov.justice.laa.dstew.access.command.application.note;
 
-import java.sql.SQLException;
-import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 
 /** Dispatches a create-note command with a single retry on concurrent-write failures. */
 @Component
 public class CreateNoteUseCase {
 
-  private final CommandGateway commandGateway;
+  private final RetryingCommandDispatcher dispatcher;
 
-  public CreateNoteUseCase(CommandGateway commandGateway) {
-    this.commandGateway = commandGateway;
+  public CreateNoteUseCase(RetryingCommandDispatcher dispatcher) {
+    this.dispatcher = dispatcher;
   }
 
   /** Dispatches the command to the application aggregate. */
   public void execute(CreateNoteCommand command) {
-    try {
-      commandGateway.sendAndWait(command);
-    } catch (RuntimeException first) {
-      if (!isRetryableConcurrentWrite(first)) {
-        throw first;
-      }
-      try {
-        commandGateway.sendAndWait(command);
-      } catch (RuntimeException retry) {
-        retry.addSuppressed(first);
-        throw retry;
-      }
-    }
-  }
-
-  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
-    return exception instanceof ConcurrencyException
-        || exception instanceof AppendEventsTransactionRejectedException
-        || exception instanceof DataIntegrityViolationException
-            && hasUniqueConstraintViolation(exception);
-  }
-
-  private boolean hasUniqueConstraintViolation(Throwable exception) {
-    Throwable cause = exception;
-    while (cause != null) {
-      if (cause instanceof SQLException sqlException
-          && "23505".equals(sqlException.getSQLState())) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
+    dispatcher.dispatch(command);
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandController.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandController.java
@@ -3,12 +3,7 @@ package uk.gov.justice.laa.dstew.access.controller.application;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.net.URI;
-import java.sql.SQLException;
 import java.util.UUID;
-import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,46 +14,53 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationCommand;
-import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerService;
+import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.UnassignCaseworkerUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.decision.MakeApplicationDecisionUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.note.CreateNoteUseCase;
 import uk.gov.justice.laa.dstew.access.model.ApplicationCreateRequest;
 import uk.gov.justice.laa.dstew.access.model.CaseworkerAssignRequest;
 import uk.gov.justice.laa.dstew.access.model.CaseworkerUnassignRequest;
 import uk.gov.justice.laa.dstew.access.model.CreateNoteRequest;
 import uk.gov.justice.laa.dstew.access.model.MakeDecisionRequest;
 import uk.gov.justice.laa.dstew.access.model.ServiceName;
-import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
-import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
-import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
 
 /** HTTP command adapter for Application writes. */
 @RestController
 @RequestMapping("/api/v0/applications")
 public class ApplicationCommandController {
 
-  private final CommandGateway commandGateway;
-  private final SubscriptionProjectionGateway projectionGateway;
+  private final CreateApplicationUseCase createApplicationUseCase;
+  private final MakeApplicationDecisionUseCase makeDecisionUseCase;
+  private final CreateNoteUseCase createNoteUseCase;
+  private final UnassignCaseworkerUseCase unassignCaseworkerUseCase;
+  private final AssignCaseworkerUseCase assignCaseworkerUseCase;
   private final CreateApplicationCommandMapper commandMapper;
   private final MakeDecisionCommandMapper decisionCommandMapper;
-  private final AssignCaseworkerService assignCaseworkerService;
   private final AssignCaseworkerRequestMapper assignCaseworkerRequestMapper;
   private final UnassignCaseworkerRequestMapper unassignCaseworkerRequestMapper;
   private final CreateNoteCommandMapper createNoteCommandMapper;
 
   /** Creates the command adapter. */
   public ApplicationCommandController(
-      CommandGateway commandGateway,
-      SubscriptionProjectionGateway projectionGateway,
+      CreateApplicationUseCase createApplicationUseCase,
+      MakeApplicationDecisionUseCase makeDecisionUseCase,
+      CreateNoteUseCase createNoteUseCase,
+      UnassignCaseworkerUseCase unassignCaseworkerUseCase,
+      AssignCaseworkerUseCase assignCaseworkerUseCase,
       CreateApplicationCommandMapper commandMapper,
       MakeDecisionCommandMapper decisionCommandMapper,
-      AssignCaseworkerService assignCaseworkerService,
       AssignCaseworkerRequestMapper assignCaseworkerRequestMapper,
       UnassignCaseworkerRequestMapper unassignCaseworkerRequestMapper,
       CreateNoteCommandMapper createNoteCommandMapper) {
-    this.commandGateway = commandGateway;
-    this.projectionGateway = projectionGateway;
+    this.createApplicationUseCase = createApplicationUseCase;
+    this.makeDecisionUseCase = makeDecisionUseCase;
+    this.createNoteUseCase = createNoteUseCase;
+    this.unassignCaseworkerUseCase = unassignCaseworkerUseCase;
+    this.assignCaseworkerUseCase = assignCaseworkerUseCase;
     this.commandMapper = commandMapper;
     this.decisionCommandMapper = decisionCommandMapper;
-    this.assignCaseworkerService = assignCaseworkerService;
     this.assignCaseworkerRequestMapper = assignCaseworkerRequestMapper;
     this.unassignCaseworkerRequestMapper = unassignCaseworkerRequestMapper;
     this.createNoteCommandMapper = createNoteCommandMapper;
@@ -70,7 +72,7 @@ public class ApplicationCommandController {
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @Valid @RequestBody CaseworkerAssignRequest request) {
     var assignment = assignCaseworkerRequestMapper.toAssignment(request);
-    assignCaseworkerService.assign(
+    assignCaseworkerUseCase.assign(
         assignment.caseworkerId(),
         assignment.applicationId(),
         assignment.serialisedRequest(),
@@ -84,7 +86,7 @@ public class ApplicationCommandController {
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @PathVariable UUID id,
       @Valid @RequestBody CaseworkerUnassignRequest request) {
-    dispatchWithRetry(unassignCaseworkerRequestMapper.toCommand(id, request));
+    unassignCaseworkerUseCase.execute(unassignCaseworkerRequestMapper.toCommand(id, request));
     return ResponseEntity.ok().build();
   }
 
@@ -94,7 +96,7 @@ public class ApplicationCommandController {
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @PathVariable UUID id,
       @Valid @RequestBody MakeDecisionRequest request) {
-    dispatchWithRetry(decisionCommandMapper.toCommand(id, request));
+    makeDecisionUseCase.execute(decisionCommandMapper.toCommand(id, request));
     return ResponseEntity.noContent().build();
   }
 
@@ -104,7 +106,7 @@ public class ApplicationCommandController {
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @PathVariable UUID id,
       @Valid @RequestBody CreateNoteRequest request) {
-    dispatchWithRetry(createNoteCommandMapper.toCommand(id, request));
+    createNoteUseCase.execute(createNoteCommandMapper.toCommand(id, request));
     return ResponseEntity.noContent().build();
   }
 
@@ -123,49 +125,10 @@ public class ApplicationCommandController {
             .buildAndExpand(command.applicationId())
             .toUri();
 
-    boolean projected =
-        projectionGateway.awaitProjection(
-            new FindApplicationByIdQuery(command.applicationId()),
-            ApplicationReadModel.class,
-            () -> dispatchWithRetry(command));
+    boolean projected = createApplicationUseCase.execute(command);
 
     return projected
         ? ResponseEntity.created(location).build()
         : ResponseEntity.accepted().location(location).build();
-  }
-
-  void dispatchWithRetry(Object command) {
-    try {
-      commandGateway.sendAndWait(command);
-    } catch (RuntimeException first) {
-      if (!isRetryableConcurrentWrite(first)) {
-        throw first;
-      }
-      try {
-        commandGateway.sendAndWait(command);
-      } catch (RuntimeException retry) {
-        retry.addSuppressed(first);
-        throw retry;
-      }
-    }
-  }
-
-  private boolean isRetryableConcurrentWrite(RuntimeException exception) {
-    return exception instanceof ConcurrencyException
-        || exception instanceof AppendEventsTransactionRejectedException
-        || exception instanceof DataIntegrityViolationException
-            && hasUniqueConstraintViolation(exception);
-  }
-
-  private boolean hasUniqueConstraintViolation(Throwable exception) {
-    Throwable cause = exception;
-    while (cause != null) {
-      if (cause instanceof SQLException sqlException
-          && "23505".equals(sqlException.getSQLState())) {
-        return true;
-      }
-      cause = cause.getCause();
-    }
-    return false;
   }
 }

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/arch/AxonArchitectureTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/arch/AxonArchitectureTest.java
@@ -66,6 +66,19 @@ class AxonArchitectureTest {
   }
 
   @Test
+  void controllersMustNotDependOnCommandGateway() {
+    ArchRule rule =
+        noClasses()
+            .that()
+            .resideInAPackage("..controller..")
+            .should()
+            .dependOnClassesThat()
+            .areAssignableTo(CommandGateway.class)
+            .allowEmptyShould(true);
+    rule.check(classes);
+  }
+
+  @Test
   void aggregatesMustNotDependOnQueryGateway() {
     ArchRule rule =
         noClasses()

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcherTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcherTest.java
@@ -1,0 +1,91 @@
+package uk.gov.justice.laa.dstew.access.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+
+class RetryingCommandDispatcherTest {
+
+  private CommandGateway commandGateway;
+  private RetryingCommandDispatcher dispatcher;
+  private final Object command = new Object();
+
+  @BeforeEach
+  void setUp() {
+    commandGateway = mock(CommandGateway.class);
+    dispatcher = new RetryingCommandDispatcher(commandGateway);
+  }
+
+  @Test
+  void givenSuccessfulDispatch_whenDispatch_thenSendsOnce() {
+    dispatcher.dispatch(command);
+
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenConcurrencyException_whenDispatch_thenRetriesOnce() {
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(new ConcurrencyException("concurrent write"))
+        .thenReturn(null);
+
+    dispatcher.dispatch(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenUniqueConstraintViolation_whenDispatch_thenRetriesOnce() {
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key", new SQLException("duplicate key value", "23505")))
+        .thenReturn(null);
+
+    dispatcher.dispatch(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenOtherDataIntegrityViolation_whenDispatch_thenPropagatesWithoutRetry() {
+    DataIntegrityViolationException failure =
+        new DataIntegrityViolationException(
+            "foreign key violation", new SQLException("missing reference", "23503"));
+    when(commandGateway.sendAndWait(command)).thenThrow(failure);
+
+    assertThatThrownBy(() -> dispatcher.dispatch(command)).isSameAs(failure);
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenNonRetryableException_whenDispatch_thenPropagatesWithoutRetry() {
+    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
+    when(commandGateway.sendAndWait(command)).thenThrow(failure);
+
+    assertThatThrownBy(() -> dispatcher.dispatch(command)).isSameAs(failure);
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenRetryAlsoFails_whenDispatch_thenRethrowsWithOriginalSuppressed() {
+    ConcurrencyException first = new ConcurrencyException("first");
+    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
+    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
+
+    assertThatThrownBy(() -> dispatcher.dispatch(command))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCaseTest.java
@@ -5,35 +5,30 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DataIntegrityViolationException;
-import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
 import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
 
 class CreateApplicationUseCaseTest {
 
-  private CommandGateway commandGateway;
+  private RetryingCommandDispatcher dispatcher;
   private SubscriptionProjectionGateway projectionGateway;
   private CreateApplicationUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    commandGateway = mock(CommandGateway.class);
+    dispatcher = mock(RetryingCommandDispatcher.class);
     projectionGateway = mock(SubscriptionProjectionGateway.class);
-    useCase = new CreateApplicationUseCase(commandGateway, projectionGateway);
+    useCase = new CreateApplicationUseCase(dispatcher, projectionGateway);
   }
 
   @Test
@@ -64,7 +59,7 @@ class CreateApplicationUseCaseTest {
   }
 
   @Test
-  void givenSuccessfulDispatch_whenExecuteViaAction_thenSendsCommandOnce() {
+  void givenProjection_whenExecute_thenDispatchesViaRetryingDispatcher() {
     CreateApplicationCommand command = stubCommand();
     doAnswer(
             invocation -> {
@@ -77,69 +72,7 @@ class CreateApplicationUseCaseTest {
 
     useCase.execute(command);
 
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenConcurrencyException_whenExecuteViaAction_thenRetriesOnce() {
-    CreateApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(new ConcurrencyException("concurrent write"))
-        .thenReturn(null);
-    doAnswer(
-            invocation -> {
-              Runnable action = invocation.getArgument(2);
-              action.run();
-              return true;
-            })
-        .when(projectionGateway)
-        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenUniqueConstraintViolation_whenExecuteViaAction_thenRetriesOnce() {
-    CreateApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "duplicate key", new SQLException("duplicate key value", "23505")))
-        .thenReturn(null);
-    doAnswer(
-            invocation -> {
-              Runnable action = invocation.getArgument(2);
-              action.run();
-              return true;
-            })
-        .when(projectionGateway)
-        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenRetryAlsoFails_whenExecuteViaAction_thenRethrowsWithOriginalSuppressed() {
-    CreateApplicationCommand command = stubCommand();
-    ConcurrencyException first = new ConcurrencyException("first");
-    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
-    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
-    doAnswer(
-            invocation -> {
-              Runnable action = invocation.getArgument(2);
-              action.run();
-              return true;
-            })
-        .when(projectionGateway)
-        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
-
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> useCase.execute(command))
-        .isInstanceOf(ResourceNotFoundException.class)
-        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+    verify(dispatcher).dispatch(command);
   }
 
   private CreateApplicationCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCaseTest.java
@@ -1,0 +1,158 @@
+package uk.gov.justice.laa.dstew.access.command.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
+import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
+import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
+
+class CreateApplicationUseCaseTest {
+
+  private CommandGateway commandGateway;
+  private SubscriptionProjectionGateway projectionGateway;
+  private CreateApplicationUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    commandGateway = mock(CommandGateway.class);
+    projectionGateway = mock(SubscriptionProjectionGateway.class);
+    useCase = new CreateApplicationUseCase(commandGateway, projectionGateway);
+  }
+
+  @Test
+  void givenProjectionConfirmed_whenExecute_thenReturnsTrue() {
+    CreateApplicationCommand command = stubCommand();
+    when(projectionGateway.awaitProjection(any(), eq(ApplicationReadModel.class), any()))
+        .thenReturn(true);
+
+    boolean result = useCase.execute(command);
+
+    assertThat(result).isTrue();
+    verify(projectionGateway)
+        .awaitProjection(
+            eq(new FindApplicationByIdQuery(command.applicationId())),
+            eq(ApplicationReadModel.class),
+            any());
+  }
+
+  @Test
+  void givenProjectionTimeout_whenExecute_thenReturnsFalse() {
+    CreateApplicationCommand command = stubCommand();
+    when(projectionGateway.awaitProjection(any(), eq(ApplicationReadModel.class), any()))
+        .thenReturn(false);
+
+    boolean result = useCase.execute(command);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void givenSuccessfulDispatch_whenExecuteViaAction_thenSendsCommandOnce() {
+    CreateApplicationCommand command = stubCommand();
+    doAnswer(
+            invocation -> {
+              Runnable action = invocation.getArgument(2);
+              action.run();
+              return true;
+            })
+        .when(projectionGateway)
+        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenConcurrencyException_whenExecuteViaAction_thenRetriesOnce() {
+    CreateApplicationCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(new ConcurrencyException("concurrent write"))
+        .thenReturn(null);
+    doAnswer(
+            invocation -> {
+              Runnable action = invocation.getArgument(2);
+              action.run();
+              return true;
+            })
+        .when(projectionGateway)
+        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenUniqueConstraintViolation_whenExecuteViaAction_thenRetriesOnce() {
+    CreateApplicationCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key", new SQLException("duplicate key value", "23505")))
+        .thenReturn(null);
+    doAnswer(
+            invocation -> {
+              Runnable action = invocation.getArgument(2);
+              action.run();
+              return true;
+            })
+        .when(projectionGateway)
+        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenRetryAlsoFails_whenExecuteViaAction_thenRethrowsWithOriginalSuppressed() {
+    CreateApplicationCommand command = stubCommand();
+    ConcurrencyException first = new ConcurrencyException("first");
+    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
+    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
+    doAnswer(
+            invocation -> {
+              Runnable action = invocation.getArgument(2);
+              action.run();
+              return true;
+            })
+        .when(projectionGateway)
+        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+  }
+
+  private CreateApplicationCommand stubCommand() {
+    UUID id = UUID.randomUUID();
+    return new CreateApplicationCommand(
+        id,
+        "APPLICATION_SUBMITTED",
+        "LAA-123",
+        Map.of("id", id.toString()),
+        List.of(),
+        "{}",
+        1,
+        "ApplyApplication.json",
+        "APPLY");
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCaseTest.java
@@ -16,17 +16,17 @@ import org.mockito.ArgumentCaptor;
 import uk.gov.justice.laa.dstew.access.command.caseworker.CaseworkerRepository;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 
-class AssignCaseworkerServiceTest {
+class AssignCaseworkerUseCaseTest {
 
   private CaseworkerRepository caseworkerRepository;
   private CommandGateway commandGateway;
-  private AssignCaseworkerService service;
+  private AssignCaseworkerUseCase useCase;
 
   @BeforeEach
   void setUp() {
     caseworkerRepository = mock(CaseworkerRepository.class);
     commandGateway = mock(CommandGateway.class);
-    service = new AssignCaseworkerService(caseworkerRepository, commandGateway);
+    useCase = new AssignCaseworkerUseCase(caseworkerRepository, commandGateway);
   }
 
   @Test
@@ -36,7 +36,7 @@ class AssignCaseworkerServiceTest {
     when(caseworkerRepository.existsById(caseworkerId)).thenReturn(true);
     Instant before = Instant.now();
 
-    service.assign(caseworkerId, applicationId, "request", "description");
+    useCase.assign(caseworkerId, applicationId, "request", "description");
 
     ArgumentCaptor<AssignCaseworkerToApplicationCommand> captor =
         ArgumentCaptor.forClass(AssignCaseworkerToApplicationCommand.class);
@@ -57,7 +57,7 @@ class AssignCaseworkerServiceTest {
     UUID caseworkerId = UUID.randomUUID();
     UUID applicationId = UUID.randomUUID();
 
-    assertThatThrownBy(() -> service.assign(caseworkerId, applicationId, "{}", null))
+    assertThatThrownBy(() -> useCase.assign(caseworkerId, applicationId, "{}", null))
         .isInstanceOf(ResourceNotFoundException.class)
         .hasMessage("No caseworker found with id: " + caseworkerId);
 

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCaseTest.java
@@ -1,88 +1,32 @@
 package uk.gov.justice.laa.dstew.access.command.application.assignment;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DataIntegrityViolationException;
-import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 
 class UnassignCaseworkerUseCaseTest {
 
-  private CommandGateway commandGateway;
+  private RetryingCommandDispatcher dispatcher;
   private UnassignCaseworkerUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    commandGateway = mock(CommandGateway.class);
-    useCase = new UnassignCaseworkerUseCase(commandGateway);
+    dispatcher = mock(RetryingCommandDispatcher.class);
+    useCase = new UnassignCaseworkerUseCase(dispatcher);
   }
 
   @Test
-  void givenSuccessfulDispatch_whenExecute_thenSendsOnce() {
+  void givenCommand_whenExecute_thenDelegatesToRetryingDispatcher() {
     UnassignCaseworkerFromApplicationCommand command = stubCommand();
 
     useCase.execute(command);
 
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenConcurrencyException_whenExecute_thenRetriesOnce() {
-    UnassignCaseworkerFromApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(new ConcurrencyException("concurrent write"))
-        .thenReturn(null);
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenUniqueConstraintViolation_whenExecute_thenRetriesOnce() {
-    UnassignCaseworkerFromApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "duplicate key", new SQLException("duplicate key value", "23505")))
-        .thenReturn(null);
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenNonRetryableException_whenExecute_thenPropagatesWithoutRetry() {
-    UnassignCaseworkerFromApplicationCommand command = stubCommand();
-    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
-    when(commandGateway.sendAndWait(command)).thenThrow(failure);
-
-    assertThatThrownBy(() -> useCase.execute(command)).isSameAs(failure);
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenRetryAlsoFails_whenExecute_thenRethrowsWithOriginalSuppressed() {
-    UnassignCaseworkerFromApplicationCommand command = stubCommand();
-    ConcurrencyException first = new ConcurrencyException("first");
-    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
-    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
-
-    assertThatThrownBy(() -> useCase.execute(command))
-        .isInstanceOf(ResourceNotFoundException.class)
-        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+    verify(dispatcher).dispatch(command);
   }
 
   private UnassignCaseworkerFromApplicationCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCaseTest.java
@@ -1,0 +1,92 @@
+package uk.gov.justice.laa.dstew.access.command.application.assignment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.UUID;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+
+class UnassignCaseworkerUseCaseTest {
+
+  private CommandGateway commandGateway;
+  private UnassignCaseworkerUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    commandGateway = mock(CommandGateway.class);
+    useCase = new UnassignCaseworkerUseCase(commandGateway);
+  }
+
+  @Test
+  void givenSuccessfulDispatch_whenExecute_thenSendsOnce() {
+    UnassignCaseworkerFromApplicationCommand command = stubCommand();
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenConcurrencyException_whenExecute_thenRetriesOnce() {
+    UnassignCaseworkerFromApplicationCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(new ConcurrencyException("concurrent write"))
+        .thenReturn(null);
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenUniqueConstraintViolation_whenExecute_thenRetriesOnce() {
+    UnassignCaseworkerFromApplicationCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key", new SQLException("duplicate key value", "23505")))
+        .thenReturn(null);
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenNonRetryableException_whenExecute_thenPropagatesWithoutRetry() {
+    UnassignCaseworkerFromApplicationCommand command = stubCommand();
+    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
+    when(commandGateway.sendAndWait(command)).thenThrow(failure);
+
+    assertThatThrownBy(() -> useCase.execute(command)).isSameAs(failure);
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenRetryAlsoFails_whenExecute_thenRethrowsWithOriginalSuppressed() {
+    UnassignCaseworkerFromApplicationCommand command = stubCommand();
+    ConcurrencyException first = new ConcurrencyException("first");
+    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
+    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
+
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+  }
+
+  private UnassignCaseworkerFromApplicationCommand stubCommand() {
+    return new UnassignCaseworkerFromApplicationCommand(
+        UUID.randomUUID(), "{}", "unassign", Instant.now());
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCaseTest.java
@@ -1,89 +1,33 @@
 package uk.gov.justice.laa.dstew.access.command.application.decision;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DataIntegrityViolationException;
-import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 
 class MakeApplicationDecisionUseCaseTest {
 
-  private CommandGateway commandGateway;
+  private RetryingCommandDispatcher dispatcher;
   private MakeApplicationDecisionUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    commandGateway = mock(CommandGateway.class);
-    useCase = new MakeApplicationDecisionUseCase(commandGateway);
+    dispatcher = mock(RetryingCommandDispatcher.class);
+    useCase = new MakeApplicationDecisionUseCase(dispatcher);
   }
 
   @Test
-  void givenSuccessfulDispatch_whenExecute_thenSendsOnce() {
+  void givenCommand_whenExecute_thenDelegatesToRetryingDispatcher() {
     MakeApplicationDecisionCommand command = stubCommand();
 
     useCase.execute(command);
 
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenConcurrencyException_whenExecute_thenRetriesOnce() {
-    MakeApplicationDecisionCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(new ConcurrencyException("concurrent write"))
-        .thenReturn(null);
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenUniqueConstraintViolation_whenExecute_thenRetriesOnce() {
-    MakeApplicationDecisionCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "duplicate key", new SQLException("duplicate key value", "23505")))
-        .thenReturn(null);
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenNonRetryableException_whenExecute_thenPropagatesWithoutRetry() {
-    MakeApplicationDecisionCommand command = stubCommand();
-    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
-    when(commandGateway.sendAndWait(command)).thenThrow(failure);
-
-    assertThatThrownBy(() -> useCase.execute(command)).isSameAs(failure);
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenRetryAlsoFails_whenExecute_thenRethrowsWithOriginalSuppressed() {
-    MakeApplicationDecisionCommand command = stubCommand();
-    ConcurrencyException first = new ConcurrencyException("first");
-    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
-    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
-
-    assertThatThrownBy(() -> useCase.execute(command))
-        .isInstanceOf(ResourceNotFoundException.class)
-        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+    verify(dispatcher).dispatch(command);
   }
 
   private MakeApplicationDecisionCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCaseTest.java
@@ -1,0 +1,93 @@
+package uk.gov.justice.laa.dstew.access.command.application.decision;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+
+class MakeApplicationDecisionUseCaseTest {
+
+  private CommandGateway commandGateway;
+  private MakeApplicationDecisionUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    commandGateway = mock(CommandGateway.class);
+    useCase = new MakeApplicationDecisionUseCase(commandGateway);
+  }
+
+  @Test
+  void givenSuccessfulDispatch_whenExecute_thenSendsOnce() {
+    MakeApplicationDecisionCommand command = stubCommand();
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenConcurrencyException_whenExecute_thenRetriesOnce() {
+    MakeApplicationDecisionCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(new ConcurrencyException("concurrent write"))
+        .thenReturn(null);
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenUniqueConstraintViolation_whenExecute_thenRetriesOnce() {
+    MakeApplicationDecisionCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key", new SQLException("duplicate key value", "23505")))
+        .thenReturn(null);
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenNonRetryableException_whenExecute_thenPropagatesWithoutRetry() {
+    MakeApplicationDecisionCommand command = stubCommand();
+    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
+    when(commandGateway.sendAndWait(command)).thenThrow(failure);
+
+    assertThatThrownBy(() -> useCase.execute(command)).isSameAs(failure);
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenRetryAlsoFails_whenExecute_thenRethrowsWithOriginalSuppressed() {
+    MakeApplicationDecisionCommand command = stubCommand();
+    ConcurrencyException first = new ConcurrencyException("first");
+    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
+    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
+
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+  }
+
+  private MakeApplicationDecisionCommand stubCommand() {
+    return new MakeApplicationDecisionCommand(
+        UUID.randomUUID(), 0L, "GRANTED", false, List.of(), null, "{}", "decision", Instant.now());
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCaseTest.java
@@ -1,88 +1,32 @@
 package uk.gov.justice.laa.dstew.access.command.application.note;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
 import java.time.Instant;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DataIntegrityViolationException;
-import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 
 class CreateNoteUseCaseTest {
 
-  private CommandGateway commandGateway;
+  private RetryingCommandDispatcher dispatcher;
   private CreateNoteUseCase useCase;
 
   @BeforeEach
   void setUp() {
-    commandGateway = mock(CommandGateway.class);
-    useCase = new CreateNoteUseCase(commandGateway);
+    dispatcher = mock(RetryingCommandDispatcher.class);
+    useCase = new CreateNoteUseCase(dispatcher);
   }
 
   @Test
-  void givenSuccessfulDispatch_whenExecute_thenSendsOnce() {
+  void givenCommand_whenExecute_thenDelegatesToRetryingDispatcher() {
     CreateNoteCommand command = stubCommand();
 
     useCase.execute(command);
 
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenConcurrencyException_whenExecute_thenRetriesOnce() {
-    CreateNoteCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(new ConcurrencyException("concurrent write"))
-        .thenReturn(null);
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenUniqueConstraintViolation_whenExecute_thenRetriesOnce() {
-    CreateNoteCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "duplicate key", new SQLException("duplicate key value", "23505")))
-        .thenReturn(null);
-
-    useCase.execute(command);
-
-    verify(commandGateway, times(2)).sendAndWait(command);
-  }
-
-  @Test
-  void givenNonRetryableException_whenExecute_thenPropagatesWithoutRetry() {
-    CreateNoteCommand command = stubCommand();
-    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
-    when(commandGateway.sendAndWait(command)).thenThrow(failure);
-
-    assertThatThrownBy(() -> useCase.execute(command)).isSameAs(failure);
-    verify(commandGateway, times(1)).sendAndWait(command);
-  }
-
-  @Test
-  void givenRetryAlsoFails_whenExecute_thenRethrowsWithOriginalSuppressed() {
-    CreateNoteCommand command = stubCommand();
-    ConcurrencyException first = new ConcurrencyException("first");
-    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
-    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
-
-    assertThatThrownBy(() -> useCase.execute(command))
-        .isInstanceOf(ResourceNotFoundException.class)
-        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+    verify(dispatcher).dispatch(command);
   }
 
   private CreateNoteCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCaseTest.java
@@ -1,0 +1,91 @@
+package uk.gov.justice.laa.dstew.access.command.application.note;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.UUID;
+import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import org.axonframework.modelling.ConcurrencyException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
+import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
+
+class CreateNoteUseCaseTest {
+
+  private CommandGateway commandGateway;
+  private CreateNoteUseCase useCase;
+
+  @BeforeEach
+  void setUp() {
+    commandGateway = mock(CommandGateway.class);
+    useCase = new CreateNoteUseCase(commandGateway);
+  }
+
+  @Test
+  void givenSuccessfulDispatch_whenExecute_thenSendsOnce() {
+    CreateNoteCommand command = stubCommand();
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenConcurrencyException_whenExecute_thenRetriesOnce() {
+    CreateNoteCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(new ConcurrencyException("concurrent write"))
+        .thenReturn(null);
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenUniqueConstraintViolation_whenExecute_thenRetriesOnce() {
+    CreateNoteCommand command = stubCommand();
+    when(commandGateway.sendAndWait(command))
+        .thenThrow(
+            new DataIntegrityViolationException(
+                "duplicate key", new SQLException("duplicate key value", "23505")))
+        .thenReturn(null);
+
+    useCase.execute(command);
+
+    verify(commandGateway, times(2)).sendAndWait(command);
+  }
+
+  @Test
+  void givenNonRetryableException_whenExecute_thenPropagatesWithoutRetry() {
+    CreateNoteCommand command = stubCommand();
+    ResourceNotFoundException failure = new ResourceNotFoundException("not found");
+    when(commandGateway.sendAndWait(command)).thenThrow(failure);
+
+    assertThatThrownBy(() -> useCase.execute(command)).isSameAs(failure);
+    verify(commandGateway, times(1)).sendAndWait(command);
+  }
+
+  @Test
+  void givenRetryAlsoFails_whenExecute_thenRethrowsWithOriginalSuppressed() {
+    CreateNoteCommand command = stubCommand();
+    ConcurrencyException first = new ConcurrencyException("first");
+    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
+    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
+
+    assertThatThrownBy(() -> useCase.execute(command))
+        .isInstanceOf(ResourceNotFoundException.class)
+        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+  }
+
+  private CreateNoteCommand stubCommand() {
+    return new CreateNoteCommand(UUID.randomUUID(), "note text", "{}", Instant.now());
+  }
+}

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandControllerTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandControllerTest.java
@@ -1,122 +1,162 @@
 package uk.gov.justice.laa.dstew.access.controller.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
-import org.axonframework.modelling.ConcurrencyException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationCommand;
-import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerService;
-import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
-import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
+import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.CaseworkerAssignment;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.UnassignCaseworkerFromApplicationCommand;
+import uk.gov.justice.laa.dstew.access.command.application.assignment.UnassignCaseworkerUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.decision.MakeApplicationDecisionCommand;
+import uk.gov.justice.laa.dstew.access.command.application.decision.MakeApplicationDecisionUseCase;
+import uk.gov.justice.laa.dstew.access.command.application.note.CreateNoteCommand;
+import uk.gov.justice.laa.dstew.access.command.application.note.CreateNoteUseCase;
 
-/**
- * Focused unit coverage for {@link ApplicationCommandController#dispatchWithRetry}.
- *
- * <p>Projection-wait semantics are covered by {@code SubscriptionProjectionGatewayTest}.
- */
+/** Verifies that each controller endpoint delegates to the appropriate use case. */
 class ApplicationCommandControllerTest {
 
-  private CommandGateway commandGateway;
+  private CreateApplicationUseCase createApplicationUseCase;
+  private MakeApplicationDecisionUseCase makeDecisionUseCase;
+  private CreateNoteUseCase createNoteUseCase;
+  private UnassignCaseworkerUseCase unassignCaseworkerUseCase;
+  private AssignCaseworkerUseCase assignCaseworkerUseCase;
+  private CreateApplicationCommandMapper commandMapper;
+  private MakeDecisionCommandMapper decisionCommandMapper;
+  private AssignCaseworkerRequestMapper assignCaseworkerRequestMapper;
+  private UnassignCaseworkerRequestMapper unassignCaseworkerRequestMapper;
+  private CreateNoteCommandMapper createNoteCommandMapper;
   private ApplicationCommandController controller;
 
   @BeforeEach
   void setUp() {
-    commandGateway = mock(CommandGateway.class);
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+    createApplicationUseCase = mock(CreateApplicationUseCase.class);
+    makeDecisionUseCase = mock(MakeApplicationDecisionUseCase.class);
+    createNoteUseCase = mock(CreateNoteUseCase.class);
+    unassignCaseworkerUseCase = mock(UnassignCaseworkerUseCase.class);
+    assignCaseworkerUseCase = mock(AssignCaseworkerUseCase.class);
+    commandMapper = mock(CreateApplicationCommandMapper.class);
+    decisionCommandMapper = mock(MakeDecisionCommandMapper.class);
+    assignCaseworkerRequestMapper = mock(AssignCaseworkerRequestMapper.class);
+    unassignCaseworkerRequestMapper = mock(UnassignCaseworkerRequestMapper.class);
+    createNoteCommandMapper = mock(CreateNoteCommandMapper.class);
     controller =
         new ApplicationCommandController(
-            commandGateway,
-            mock(SubscriptionProjectionGateway.class),
-            mock(CreateApplicationCommandMapper.class),
-            mock(MakeDecisionCommandMapper.class),
-            mock(AssignCaseworkerService.class),
-            mock(AssignCaseworkerRequestMapper.class),
-            mock(UnassignCaseworkerRequestMapper.class),
-            mock(CreateNoteCommandMapper.class));
+            createApplicationUseCase,
+            makeDecisionUseCase,
+            createNoteUseCase,
+            unassignCaseworkerUseCase,
+            assignCaseworkerUseCase,
+            commandMapper,
+            decisionCommandMapper,
+            assignCaseworkerRequestMapper,
+            unassignCaseworkerRequestMapper,
+            createNoteCommandMapper);
+  }
+
+  @AfterEach
+  void tearDown() {
+    RequestContextHolder.resetRequestAttributes();
   }
 
   @Test
-  void givenSuccessfulDispatch_whenDispatchWithRetry_thenSendsOnce() {
-    CreateApplicationCommand command = stubCommand();
+  void givenProjectedResult_whenCreateApplication_thenDelegatesToUseCaseAndReturns201() {
+    CreateApplicationCommand command = stubCreateCommand();
+    when(commandMapper.toCommand(any(), anyInt())).thenReturn(command);
+    when(createApplicationUseCase.execute(command)).thenReturn(true);
 
-    controller.dispatchWithRetry(command);
+    ResponseEntity<Void> response = controller.createApplication(null, 1, null);
 
-    verify(commandGateway, times(1)).sendAndWait(command);
+    verify(createApplicationUseCase).execute(command);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
   }
 
   @Test
-  void givenConcurrencyException_whenDispatchWithRetry_thenRetriesOnce() {
-    CreateApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(new ConcurrencyException("concurrent write"))
-        .thenReturn(null);
+  void givenTimeoutResult_whenCreateApplication_thenDelegatesToUseCaseAndReturns202() {
+    CreateApplicationCommand command = stubCreateCommand();
+    when(commandMapper.toCommand(any(), anyInt())).thenReturn(command);
+    when(createApplicationUseCase.execute(command)).thenReturn(false);
 
-    controller.dispatchWithRetry(command);
+    ResponseEntity<Void> response = controller.createApplication(null, 1, null);
 
-    verify(commandGateway, times(2)).sendAndWait(command);
+    verify(createApplicationUseCase).execute(command);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
   }
 
   @Test
-  void givenUniqueConstraintViolation_whenDispatchWithRetry_thenRetriesOnce() {
-    CreateApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(
-            new DataIntegrityViolationException(
-                "concurrent data version", new SQLException("duplicate key", "23505")))
-        .thenReturn(null);
+  void givenRequest_whenMakeDecision_thenDelegatesToUseCase() {
+    UUID id = UUID.randomUUID();
+    MakeApplicationDecisionCommand command = mock(MakeApplicationDecisionCommand.class);
+    when(decisionCommandMapper.toCommand(id, null)).thenReturn(command);
 
-    controller.dispatchWithRetry(command);
+    controller.makeDecision(null, id, null);
 
-    verify(commandGateway, times(2)).sendAndWait(command);
+    verify(makeDecisionUseCase).execute(command);
   }
 
   @Test
-  void givenOtherDataIntegrityViolation_whenDispatchWithRetry_thenPropagatesWithoutRetry() {
-    CreateApplicationCommand command = stubCommand();
-    DataIntegrityViolationException failure =
-        new DataIntegrityViolationException(
-            "foreign key violation", new SQLException("missing reference", "23503"));
-    when(commandGateway.sendAndWait(command)).thenThrow(failure);
+  void givenRequest_whenCreateNote_thenDelegatesToUseCase() {
+    UUID id = UUID.randomUUID();
+    CreateNoteCommand command = mock(CreateNoteCommand.class);
+    when(createNoteCommandMapper.toCommand(id, null)).thenReturn(command);
 
-    assertThatThrownBy(() -> controller.dispatchWithRetry(command)).isSameAs(failure);
-    verify(commandGateway).sendAndWait(command);
+    controller.createNote(null, id, null);
+
+    verify(createNoteUseCase).execute(command);
   }
 
   @Test
-  void givenNonConcurrencyException_whenDispatchWithRetry_thenPropagatesWithoutRetry() {
-    CreateApplicationCommand command = stubCommand();
-    when(commandGateway.sendAndWait(command))
-        .thenThrow(new ResourceNotFoundException("no lead application"));
+  void givenRequest_whenUnassignCaseworker_thenDelegatesToUseCase() {
+    UUID id = UUID.randomUUID();
+    UnassignCaseworkerFromApplicationCommand command =
+        mock(UnassignCaseworkerFromApplicationCommand.class);
+    when(unassignCaseworkerRequestMapper.toCommand(id, null)).thenReturn(command);
 
-    assertThatThrownBy(() -> controller.dispatchWithRetry(command))
-        .isInstanceOf(ResourceNotFoundException.class);
-    verify(commandGateway, times(1)).sendAndWait(command);
+    controller.unassignCaseworker(null, id, null);
+
+    verify(unassignCaseworkerUseCase).execute(command);
   }
 
   @Test
-  void givenRetryAlsoFails_whenDispatchWithRetry_thenRethrowsWithOriginalSuppressed() {
-    CreateApplicationCommand command = stubCommand();
-    ConcurrencyException first = new ConcurrencyException("first write");
-    ResourceNotFoundException retry = new ResourceNotFoundException("retry failure");
-    when(commandGateway.sendAndWait(command)).thenThrow(first).thenThrow(retry);
+  void givenRequest_whenAssignCaseworker_thenDelegatesToUseCase() {
+    CaseworkerAssignment assignment =
+        new CaseworkerAssignment(UUID.randomUUID(), UUID.randomUUID(), "{}", "desc");
+    when(assignCaseworkerRequestMapper.toAssignment(any())).thenReturn(assignment);
 
-    assertThatThrownBy(() -> controller.dispatchWithRetry(command))
-        .isInstanceOf(ResourceNotFoundException.class)
-        .satisfies(e -> assertThat(e.getSuppressed()).contains(first));
+    controller.assignCaseworker(null, null);
+
+    verify(assignCaseworkerUseCase)
+        .assign(
+            assignment.caseworkerId(),
+            assignment.applicationId(),
+            assignment.serialisedRequest(),
+            assignment.eventDescription());
+    verify(makeDecisionUseCase, never()).execute(any());
+    verify(createNoteUseCase, never()).execute(any());
+    verify(unassignCaseworkerUseCase, never()).execute(any());
+    verify(createApplicationUseCase, never()).execute(any());
   }
 
-  private CreateApplicationCommand stubCommand() {
+  private CreateApplicationCommand stubCreateCommand() {
     UUID id = UUID.randomUUID();
     return new CreateApplicationCommand(
         id,


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2077)

Refactored command-dispatching controllers to delegate to thin use-case wrappers, removing direct dependencies on Axon’s CommandGateway and aligning with established application-layer patterns. Updated and added tests to verify controller delegation and command dispatch behaviour while preserving existing API contracts and endpoint functionality.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
