### PR TITLE
feat: DSTEW-2081 post commands return sequence etag

### DIFF
--- a/data-access-service-axon/src/integrationTest/java/uk/gov/justice/laa/dstew/access/PostgresAxonIntegrationTest.java
+++ b/data-access-service-axon/src/integrationTest/java/uk/gov/justice/laa/dstew/access/PostgresAxonIntegrationTest.java
@@ -164,7 +164,7 @@ class PostgresAxonIntegrationTest {
             """,
             String.class);
 
-    assertThat(appliedVersions).containsExactly("1", "2", "3");
+    assertThat(appliedVersions).containsExactly("1", "2", "3", "4");
     assertThat(tables)
         .containsExactly(
             "application_current_state",

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcher.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/RetryingCommandDispatcher.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.dstew.access.command;
 
 import java.sql.SQLException;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.axonframework.eventsourcing.eventstore.AppendEventsTransactionRejectedException;
 import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
@@ -53,6 +54,47 @@ public class RetryingCommandDispatcher {
         throw retry;
       }
     }
+  }
+
+  /** Dispatches the command asynchronously, retrying once on concurrent-write failures. */
+  public CompletableFuture<Object> dispatchAsync(Object command) {
+    return commandGateway
+        .send(command, Object.class)
+        .handle(
+            (result, throwable) -> {
+              if (throwable == null) {
+                return CompletableFuture.completedFuture(result);
+              }
+              RuntimeException exception = unwrap(throwable);
+              if (!isRetryableConcurrentWrite(exception)) {
+                return CompletableFuture.<Object>failedFuture(exception);
+              }
+              return commandGateway
+                  .send(command, Object.class)
+                  .handle(
+                      (retryResult, retryThrowable) -> {
+                        if (retryThrowable == null) {
+                          return CompletableFuture.completedFuture(retryResult);
+                        }
+                        RuntimeException retryException = unwrap(retryThrowable);
+                        retryException.addSuppressed(exception);
+                        return CompletableFuture.<Object>failedFuture(retryException);
+                      })
+                  .thenCompose(future -> future);
+            })
+        .thenCompose(future -> future);
+  }
+
+  private RuntimeException unwrap(Throwable throwable) {
+    Throwable cause = throwable;
+    while (cause.getCause() != null
+        && (cause instanceof java.util.concurrent.CompletionException
+            || cause instanceof java.util.concurrent.ExecutionException)) {
+      cause = cause.getCause();
+    }
+    return cause instanceof RuntimeException runtimeException
+        ? runtimeException
+        : new RuntimeException(cause);
   }
 
   private boolean isRetryableConcurrentWrite(RuntimeException exception) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationCommandResult.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationCommandResult.java
@@ -1,0 +1,6 @@
+package uk.gov.justice.laa.dstew.access.command.application;
+
+import java.util.UUID;
+
+/** The committed aggregate sequence produced by an Application command. */
+public record ApplicationCommandResult(UUID applicationId, long aggregateSequence) {}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationEventStorePositionRepository.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/ApplicationEventStorePositionRepository.java
@@ -1,0 +1,56 @@
+package uk.gov.justice.laa.dstew.access.command.application;
+
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/** Reads committed Application aggregate positions from the Axon JPA event store. */
+@Repository
+public class ApplicationEventStorePositionRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+  private final String eventStoreTable;
+
+  public ApplicationEventStorePositionRepository(
+      JdbcTemplate jdbcTemplate,
+      @Value("${spring.jpa.properties.hibernate.default_schema:${axon.db.schema:axon}}")
+          String schema) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.eventStoreTable = schema + ".domain_event_entry";
+  }
+
+  /** Returns the latest committed event sequence for an aggregate. */
+  public long latestSequence(UUID applicationId) {
+    Long sequence =
+        jdbcTemplate.queryForObject(
+            "SELECT MAX(sequence_number) FROM "
+                + eventStoreTable
+                + " WHERE aggregate_identifier = ?",
+            Long.class,
+            applicationId.toString());
+    if (sequence == null) {
+      throw new IllegalStateException(
+          "No committed event sequence found for Application ID: " + applicationId);
+    }
+    return sequence;
+  }
+
+  /** Returns the aggregate sequence for one committed event. */
+  public long sequenceForEvent(UUID applicationId, String eventIdentifier) {
+    Long sequence =
+        jdbcTemplate.queryForObject(
+            "SELECT sequence_number FROM "
+                + eventStoreTable
+                + " "
+                + "WHERE aggregate_identifier = ? AND event_identifier = ?",
+            Long.class,
+            applicationId.toString(),
+            eventIdentifier);
+    if (sequence == null) {
+      throw new IllegalStateException(
+          "No committed event sequence found for event ID: " + eventIdentifier);
+    }
+    return sequence;
+  }
+}

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCase.java
@@ -1,37 +1,31 @@
 package uk.gov.justice.laa.dstew.access.command.application;
 
+import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
-import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
-import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
-import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
 
-/**
- * Dispatches a create-application command and waits for the projection to confirm the application
- * is readable.
- */
+/** Dispatches a create-application command to Axon. */
 @Component
 public class CreateApplicationUseCase {
 
   private final RetryingCommandDispatcher dispatcher;
-  private final SubscriptionProjectionGateway projectionGateway;
+  private final ApplicationEventStorePositionRepository eventStorePositionRepository;
 
   public CreateApplicationUseCase(
-      RetryingCommandDispatcher dispatcher, SubscriptionProjectionGateway projectionGateway) {
+      RetryingCommandDispatcher dispatcher,
+      ApplicationEventStorePositionRepository eventStorePositionRepository) {
     this.dispatcher = dispatcher;
-    this.projectionGateway = projectionGateway;
+    this.eventStorePositionRepository = eventStorePositionRepository;
   }
 
-  /**
-   * Dispatches the command and waits for the projection to become readable.
-   *
-   * @return {@code true} when the projection confirms the application within the configured
-   *     timeout; {@code false} on timeout — the command has still committed.
-   */
-  public boolean execute(CreateApplicationCommand command) {
-    return projectionGateway.awaitProjection(
-        new FindApplicationByIdQuery(command.applicationId()),
-        ApplicationReadModel.class,
-        () -> dispatcher.dispatch(command));
+  /** Dispatches the command and completes when Axon has handled it. */
+  public CompletableFuture<ApplicationCommandResult> execute(CreateApplicationCommand command) {
+    return dispatcher
+        .dispatchAsync(command)
+        .thenApply(
+            ignored ->
+                new ApplicationCommandResult(
+                    command.applicationId(),
+                    eventStorePositionRepository.latestSequence(command.applicationId())));
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCase.java
@@ -2,9 +2,10 @@ package uk.gov.justice.laa.dstew.access.command.application.assignment;
 
 import java.time.Instant;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 import uk.gov.justice.laa.dstew.access.command.caseworker.CaseworkerRepository;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 
@@ -13,25 +14,27 @@ import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 public class AssignCaseworkerUseCase {
 
   private final CaseworkerRepository caseworkerRepository;
-  private final CommandGateway commandGateway;
+  private final RetryingCommandDispatcher dispatcher;
 
   /** Creates the assignment coordinator with its directory and command gateway. */
   public AssignCaseworkerUseCase(
-      CaseworkerRepository caseworkerRepository, CommandGateway commandGateway) {
+      CaseworkerRepository caseworkerRepository, RetryingCommandDispatcher dispatcher) {
     this.caseworkerRepository = caseworkerRepository;
-    this.commandGateway = commandGateway;
+    this.dispatcher = dispatcher;
   }
 
   /** Validates and assigns the caseworker to one Application. */
   @Transactional
-  public void assign(
+  public CompletableFuture<Void> assign(
       UUID caseworkerId, UUID applicationId, String serialisedRequest, String eventDescription) {
     if (!caseworkerRepository.existsById(caseworkerId)) {
       throw new ResourceNotFoundException("No caseworker found with id: " + caseworkerId);
     }
     Instant occurredAt = Instant.now();
-    commandGateway.sendAndWait(
-        new AssignCaseworkerToApplicationCommand(
-            applicationId, caseworkerId, serialisedRequest, eventDescription, occurredAt));
+    return dispatcher
+        .dispatchAsync(
+            new AssignCaseworkerToApplicationCommand(
+                applicationId, caseworkerId, serialisedRequest, eventDescription, occurredAt))
+        .thenApply(ignored -> null);
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCase.java
@@ -1,20 +1,34 @@
 package uk.gov.justice.laa.dstew.access.command.application.assignment;
 
+import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationCommandResult;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 
 /** Dispatches an unassign-caseworker command with a single retry on concurrent-write failures. */
 @Component
 public class UnassignCaseworkerUseCase {
 
   private final RetryingCommandDispatcher dispatcher;
+  private final ApplicationEventStorePositionRepository eventStorePositionRepository;
 
-  public UnassignCaseworkerUseCase(RetryingCommandDispatcher dispatcher) {
+  public UnassignCaseworkerUseCase(
+      RetryingCommandDispatcher dispatcher,
+      ApplicationEventStorePositionRepository eventStorePositionRepository) {
     this.dispatcher = dispatcher;
+    this.eventStorePositionRepository = eventStorePositionRepository;
   }
 
   /** Dispatches the command to the application aggregate. */
-  public void execute(UnassignCaseworkerFromApplicationCommand command) {
-    dispatcher.dispatch(command);
+  public CompletableFuture<ApplicationCommandResult> execute(
+      UnassignCaseworkerFromApplicationCommand command) {
+    return dispatcher
+        .dispatchAsync(command)
+        .thenApply(
+            ignored ->
+                new ApplicationCommandResult(
+                    command.applicationId(),
+                    eventStorePositionRepository.latestSequence(command.applicationId())));
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCase.java
@@ -1,20 +1,34 @@
 package uk.gov.justice.laa.dstew.access.command.application.decision;
 
+import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationCommandResult;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 
 /** Dispatches a make-decision command with a single retry on concurrent-write failures. */
 @Component
 public class MakeApplicationDecisionUseCase {
 
   private final RetryingCommandDispatcher dispatcher;
+  private final ApplicationEventStorePositionRepository eventStorePositionRepository;
 
-  public MakeApplicationDecisionUseCase(RetryingCommandDispatcher dispatcher) {
+  public MakeApplicationDecisionUseCase(
+      RetryingCommandDispatcher dispatcher,
+      ApplicationEventStorePositionRepository eventStorePositionRepository) {
     this.dispatcher = dispatcher;
+    this.eventStorePositionRepository = eventStorePositionRepository;
   }
 
   /** Dispatches the command to the application aggregate. */
-  public void execute(MakeApplicationDecisionCommand command) {
-    dispatcher.dispatch(command);
+  public CompletableFuture<ApplicationCommandResult> execute(
+      MakeApplicationDecisionCommand command) {
+    return dispatcher
+        .dispatchAsync(command)
+        .thenApply(
+            ignored ->
+                new ApplicationCommandResult(
+                    command.applicationId(),
+                    eventStorePositionRepository.latestSequence(command.applicationId())));
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCase.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCase.java
@@ -1,20 +1,33 @@
 package uk.gov.justice.laa.dstew.access.command.application.note;
 
+import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationCommandResult;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 
 /** Dispatches a create-note command with a single retry on concurrent-write failures. */
 @Component
 public class CreateNoteUseCase {
 
   private final RetryingCommandDispatcher dispatcher;
+  private final ApplicationEventStorePositionRepository eventStorePositionRepository;
 
-  public CreateNoteUseCase(RetryingCommandDispatcher dispatcher) {
+  public CreateNoteUseCase(
+      RetryingCommandDispatcher dispatcher,
+      ApplicationEventStorePositionRepository eventStorePositionRepository) {
     this.dispatcher = dispatcher;
+    this.eventStorePositionRepository = eventStorePositionRepository;
   }
 
   /** Dispatches the command to the application aggregate. */
-  public void execute(CreateNoteCommand command) {
-    dispatcher.dispatch(command);
+  public CompletableFuture<ApplicationCommandResult> execute(CreateNoteCommand command) {
+    return dispatcher
+        .dispatchAsync(command)
+        .thenApply(
+            ignored ->
+                new ApplicationCommandResult(
+                    command.applicationId(),
+                    eventStorePositionRepository.latestSequence(command.applicationId())));
   }
 }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandController.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import java.net.URI;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -86,36 +87,42 @@ public class ApplicationCommandController {
 
   /** Assigns a caseworker to one or more Applications after validating the complete batch. */
   @PostMapping("/assign")
-  public ResponseEntity<Void> assignCaseworker(
+  public CompletableFuture<ResponseEntity<Void>> assignCaseworker(
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @Valid @RequestBody CaseworkerAssignRequest request) {
     var assignment = assignCaseworkerRequestMapper.toAssignment(request);
-    assignCaseworkerUseCase.assign(
-        assignment.caseworkerId(),
-        assignment.applicationId(),
-        assignment.serialisedRequest(),
-        assignment.eventDescription());
-    return ResponseEntity.ok().build();
+    return assignCaseworkerUseCase
+        .assign(
+            assignment.caseworkerId(),
+            assignment.applicationId(),
+            assignment.serialisedRequest(),
+            assignment.eventDescription())
+        .thenApply(ignored -> ResponseEntity.ok().build());
   }
 
   /** Removes the current caseworker assignment from an Application. */
   @PostMapping("/{id}/unassign")
-  public ResponseEntity<Void> unassignCaseworker(
+  public CompletableFuture<ResponseEntity<Void>> unassignCaseworker(
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @PathVariable UUID id,
       @Valid @RequestBody CaseworkerUnassignRequest request) {
-    unassignCaseworkerUseCase.execute(unassignCaseworkerRequestMapper.toCommand(id, request));
-    return ResponseEntity.ok().build();
+    return unassignCaseworkerUseCase
+        .execute(unassignCaseworkerRequestMapper.toCommand(id, request))
+        .thenApply(
+            result -> ResponseEntity.ok().eTag("\"" + result.aggregateSequence() + "\"").build());
   }
 
   /** Applies an overall and per-proceeding decision to an existing Application version. */
   @PatchMapping("/{id}/decision")
-  public ResponseEntity<Void> makeDecision(
+  public CompletableFuture<ResponseEntity<Void>> makeDecision(
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @PathVariable UUID id,
       @Valid @RequestBody MakeDecisionRequest request) {
-    makeDecisionUseCase.execute(decisionCommandMapper.toCommand(id, request));
-    return ResponseEntity.noContent().build();
+    return makeDecisionUseCase
+        .execute(decisionCommandMapper.toCommand(id, request))
+        .thenApply(
+            result ->
+                ResponseEntity.noContent().eTag("\"" + result.aggregateSequence() + "\"").build());
   }
 
   /** Records either terminal outcome of deciding whether an Application can be auto-granted. */
@@ -137,17 +144,20 @@ public class ApplicationCommandController {
 
   /** Appends a note to an existing Application. */
   @PostMapping("/{id}/notes")
-  public ResponseEntity<Void> createNote(
+  public CompletableFuture<ResponseEntity<Void>> createNote(
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @PathVariable UUID id,
       @Valid @RequestBody CreateNoteRequest request) {
-    createNoteUseCase.execute(createNoteCommandMapper.toCommand(id, request));
-    return ResponseEntity.noContent().build();
+    return createNoteUseCase
+        .execute(createNoteCommandMapper.toCommand(id, request))
+        .thenApply(
+            result ->
+                ResponseEntity.noContent().eTag("\"" + result.aggregateSequence() + "\"").build());
   }
 
-  /** Dispatches create directly to Axon and returns 201 once the projection is readable. */
+  /** Dispatches create directly to Axon and returns once its events have committed. */
   @PostMapping
-  public ResponseEntity<Void> createApplication(
+  public CompletableFuture<ResponseEntity<Void>> createApplication(
       @RequestHeader("X-Service-Name") ServiceName serviceName,
       @RequestHeader(value = "X-Schema-Version", required = false, defaultValue = "1") @Min(1)
           int schemaVersion,
@@ -158,10 +168,14 @@ public class ApplicationCommandController {
             .path("/{id}")
             .buildAndExpand(command.applicationId())
             .toUri();
-    boolean projected = createApplicationUseCase.execute(command);
-    return projected
-        ? ResponseEntity.created(location).build()
-        : ResponseEntity.accepted().location(location).build();
+
+    return createApplicationUseCase
+        .execute(command)
+        .thenApply(
+            result ->
+                ResponseEntity.created(location)
+                    .eTag("\"" + result.aggregateSequence() + "\"")
+                    .build());
   }
 
   /** Replaces an existing Application's content and optional status. */

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationQueryController.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationQueryController.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.axonframework.messaging.queryhandling.gateway.QueryGateway;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.dstew.access.command.application.AutoGrantedState;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 import uk.gov.justice.laa.dstew.access.model.ApplicationHistoryResponse;
@@ -124,12 +126,36 @@ public class ApplicationQueryController {
 
   /** Returns the current-state projection for the requested Application. */
   @GetMapping("/{id}")
-  public ResponseEntity<ApplicationResponse> getApplicationById(@PathVariable UUID id) {
-    ApplicationReadModel application =
-        findApplicationAwaitingProjection(id)
-            .orElseThrow(
-                () -> new ResourceNotFoundException("No application found with ID: " + id));
-    return ResponseEntity.ok(responseMapper.toResponse(application));
+  public ResponseEntity<ApplicationResponse> getApplicationById(
+      @PathVariable UUID id, @RequestHeader(value = "If-Match", required = false) String ifMatch) {
+    Long expectedSequence = parseExpectedSequence(ifMatch);
+    Optional<ApplicationReadModel> application = findApplication(id);
+    if (expectedSequence != null
+        && (application.isEmpty() || application.get().getAggregateSequence() < expectedSequence)) {
+      return ResponseEntity.accepted().build();
+    }
+    ApplicationReadModel readModel =
+        application.orElseThrow(
+            () -> new ResourceNotFoundException("No application found with ID: " + id));
+    return ResponseEntity.ok()
+        .eTag("\"" + readModel.getAggregateSequence() + "\"")
+        .body(responseMapper.toResponse(readModel));
+  }
+
+  private Long parseExpectedSequence(String ifMatch) {
+    if (ifMatch == null) {
+      return null;
+    }
+    if (!ifMatch.matches("\"[0-9]+\"")) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "If-Match must be a quoted sequence ETag");
+    }
+    try {
+      return Long.parseLong(ifMatch.substring(1, ifMatch.length() - 1));
+    } catch (NumberFormatException exception) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST, "If-Match sequence is out of range", exception);
+    }
   }
 
   /** Returns the certificate stored in the Application's current immutable data version. */

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
@@ -28,7 +28,6 @@ import uk.gov.justice.laa.dstew.access.command.application.assignment.Applicatio
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataId;
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataPayload;
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataStore;
-import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationNote;
 import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
 import uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent;
 import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
@@ -96,8 +95,7 @@ public class ApplicationProjection {
               ApplicationDataPayload data =
                   applicationDataStore.get(
                       application.getApplicationId(), application.getApplicationDataVersion());
-              return new ApplicationNotesResult(
-                  data == null ? List.of() : data.notes());
+              return new ApplicationNotesResult(data == null ? List.of() : data.notes());
             })
         .orElse(null);
   }

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
@@ -97,7 +97,7 @@ public class ApplicationProjection {
                   applicationDataStore.get(
                       application.getApplicationId(), application.getApplicationDataVersion());
               return new ApplicationNotesResult(
-                  data == null ? List.<ApplicationNote>of() : data.notes());
+                  data == null ? List.of() : data.notes());
             })
         .orElse(null);
   }
@@ -243,11 +243,8 @@ public class ApplicationProjection {
 
   /** Advances current state to the updated immutable data and status. */
   @EventHandler
-  public void on(ApplicationUpdatedEvent event, QueryUpdateEmitter queryUpdateEmitter) {
   public void on(
-      ApplicationDecisionMadeEvent event,
-      EventMessage message,
-      QueryUpdateEmitter queryUpdateEmitter) {
+      ApplicationUpdatedEvent event, EventMessage message, QueryUpdateEmitter queryUpdateEmitter) {
     applicationReadRepository
         .findById(event.applicationId())
         .ifPresent(

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjection.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.axonframework.messaging.core.annotation.Namespace;
+import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.eventhandling.annotation.EventHandler;
 import org.axonframework.messaging.eventhandling.replay.annotation.ResetHandler;
 import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
@@ -19,6 +20,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationLinkedEvent;
 import uk.gov.justice.laa.dstew.access.command.application.AutoGrantedState;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationAssignedToCaseworkerEvent;
@@ -44,6 +46,7 @@ import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationLi
 public class ApplicationProjection {
 
   private final ApplicationReadRepository applicationReadRepository;
+  private final ApplicationEventStorePositionRepository eventStorePositionRepository;
   private final LinkedApplicationGroupReadRepository groupReadRepository;
   private final ApplicationDataStore applicationDataStore;
   private final ApplicationListIndexReadRepository listIndexRepository;
@@ -60,10 +63,12 @@ public class ApplicationProjection {
    */
   public ApplicationProjection(
       ApplicationReadRepository applicationReadRepository,
+      ApplicationEventStorePositionRepository eventStorePositionRepository,
       LinkedApplicationGroupReadRepository groupReadRepository,
       ApplicationDataStore applicationDataStore,
       ApplicationListIndexReadRepository listIndexRepository) {
     this.applicationReadRepository = applicationReadRepository;
+    this.eventStorePositionRepository = eventStorePositionRepository;
     this.groupReadRepository = groupReadRepository;
     this.applicationDataStore = applicationDataStore;
     this.listIndexRepository = listIndexRepository;
@@ -176,7 +181,8 @@ public class ApplicationProjection {
 
   /** Creates the current-state row from an Application's creation event. */
   @EventHandler
-  public void on(ApplicationCreatedEvent event, QueryUpdateEmitter queryUpdateEmitter) {
+  public void on(
+      ApplicationCreatedEvent event, EventMessage message, QueryUpdateEmitter queryUpdateEmitter) {
     ApplicationReadModel saved =
         applicationReadRepository.save(
             ApplicationReadModel.builder()
@@ -184,6 +190,7 @@ public class ApplicationProjection {
                 .status(event.status())
                 .applicationDataVersion(event.applicationDataVersion())
                 .applicationVersion(0L)
+                .aggregateSequence(sequenceFor(event.applicationId(), message))
                 .schemaVersion(event.schemaVersion())
                 .applicationType(event.applicationType())
                 .applyApplicationId(event.applyApplicationId())
@@ -199,13 +206,14 @@ public class ApplicationProjection {
 
   /** Updates the linked-group membership after the Application is created. */
   @EventHandler
-  public void on(ApplicationLinkedEvent event) {
+  public void on(ApplicationLinkedEvent event, EventMessage message) {
     applicationReadRepository
         .findById(event.applicationId())
         .ifPresent(
             application -> {
               application.setLeadApplicationId(event.leadApplicationId());
               application.setModifiedAt(event.occurredAt());
+              application.setAggregateSequence(sequenceFor(event.applicationId(), message));
               applicationReadRepository.save(application);
             });
   }
@@ -236,13 +244,18 @@ public class ApplicationProjection {
   /** Advances current state to the updated immutable data and status. */
   @EventHandler
   public void on(ApplicationUpdatedEvent event, QueryUpdateEmitter queryUpdateEmitter) {
+  public void on(
+      ApplicationDecisionMadeEvent event,
+      EventMessage message,
+      QueryUpdateEmitter queryUpdateEmitter) {
     applicationReadRepository
         .findById(event.applicationId())
         .ifPresent(
             application -> {
               application.setStatus(event.status());
-              application.setApplicationVersion(event.applicationVersion());
               application.setApplicationDataVersion(event.applicationDataVersion());
+              application.setApplicationVersion(event.applicationVersion());
+              application.setAggregateSequence(sequenceFor(event.applicationId(), message));
               application.setModifiedAt(event.occurredAt());
               ApplicationReadModel saved = applicationReadRepository.save(application);
               queryUpdateEmitter.emit(
@@ -254,7 +267,7 @@ public class ApplicationProjection {
 
   /** Updates the assigned caseworker and referenced application-data version. */
   @EventHandler
-  public void on(ApplicationAssignedToCaseworkerEvent event) {
+  public void on(ApplicationAssignedToCaseworkerEvent event, EventMessage message) {
     applicationReadRepository
         .findById(event.applicationId())
         .ifPresent(
@@ -262,6 +275,7 @@ public class ApplicationProjection {
               application.setCaseworkerId(event.caseworkerId());
               application.setApplicationVersion(event.applicationVersion());
               application.setApplicationDataVersion(event.applicationDataVersion());
+              application.setAggregateSequence(sequenceFor(event.applicationId(), message));
               application.setModifiedAt(event.occurredAt());
               applicationReadRepository.save(application);
             });
@@ -269,7 +283,7 @@ public class ApplicationProjection {
 
   /** Clears the assigned caseworker and updates the referenced application-data version. */
   @EventHandler
-  public void on(ApplicationUnassignedFromCaseworkerEvent event) {
+  public void on(ApplicationUnassignedFromCaseworkerEvent event, EventMessage message) {
     applicationReadRepository
         .findById(event.applicationId())
         .ifPresent(
@@ -277,6 +291,7 @@ public class ApplicationProjection {
               application.setCaseworkerId(null);
               application.setApplicationVersion(event.applicationVersion());
               application.setApplicationDataVersion(event.applicationDataVersion());
+              application.setAggregateSequence(sequenceFor(event.applicationId(), message));
               application.setModifiedAt(event.occurredAt());
               applicationReadRepository.save(application);
             });
@@ -284,12 +299,13 @@ public class ApplicationProjection {
 
   /** Advances the referenced application-data version when a note is created. */
   @EventHandler
-  public void on(NoteCreatedEvent event) {
+  public void on(NoteCreatedEvent event, EventMessage message) {
     applicationReadRepository
         .findById(event.applicationId())
         .ifPresent(
             application -> {
               application.setApplicationDataVersion(event.applicationDataVersion());
+              application.setAggregateSequence(sequenceFor(event.applicationId(), message));
               application.setModifiedAt(event.occurredAt());
               applicationReadRepository.save(application);
             });
@@ -320,6 +336,10 @@ public class ApplicationProjection {
   @ResetHandler
   public void reset() {
     applicationReadRepository.deleteAllInBatch();
+  }
+
+  private long sequenceFor(UUID applicationId, EventMessage message) {
+    return eventStorePositionRepository.sequenceForEvent(applicationId, message.identifier());
   }
 
   private Sort buildSort(String sortBy, String orderBy) {

--- a/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationReadModel.java
+++ b/data-access-service-axon/src/main/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationReadModel.java
@@ -40,6 +40,9 @@ public class ApplicationReadModel {
   @Column(name = "application_version", nullable = false)
   private long applicationVersion;
 
+  @Column(name = "aggregate_sequence", nullable = false)
+  private long aggregateSequence;
+
   @Transient private String laaReference;
 
   @Transient private ApplicationContent applicationContent;

--- a/data-access-service-axon/src/main/resources/db/migration/V4__add_application_aggregate_sequence.sql
+++ b/data-access-service-axon/src/main/resources/db/migration/V4__add_application_aggregate_sequence.sql
@@ -1,0 +1,2 @@
+ALTER TABLE application_current_state
+    ADD COLUMN aggregate_sequence BIGINT NOT NULL DEFAULT 0;

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/CreateApplicationInMemoryTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/CreateApplicationInMemoryTest.java
@@ -414,6 +414,7 @@ class CreateApplicationInMemoryTest {
             new HttpEntity<>(
                 validCreateApplicationRequest(applicationId, UUID.randomUUID()), headers()),
             Void.class));
+    awaitProjection(applicationId);
     ApplicationResponse created =
         restTemplate
             .exchange(

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/ProjectionTimeoutInMemoryTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/ProjectionTimeoutInMemoryTest.java
@@ -8,8 +8,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.axonframework.common.configuration.AxonConfiguration;
 import org.axonframework.messaging.eventhandling.processing.streaming.StreamingEventProcessor;
 import org.junit.jupiter.api.Test;
@@ -68,11 +67,11 @@ class ProjectionTimeoutInMemoryTest {
   @Test
   void givenStoppedProjectionProcessor_whenPostApplication_thenReturnsCreatedWithEtag() {
     // Stop the projection processor to prove the command response does not wait for it.
-    axonConfiguration
-        .getComponents(StreamingEventProcessor.class)
-        .get("application-projection")
-        .shutdown()
-        .join();
+    StreamingEventProcessor processor =
+        axonConfiguration
+            .getComponents(StreamingEventProcessor.class)
+            .get("application-projection");
+    processor.shutdown().join();
 
     UUID applyApplicationId = UUID.randomUUID();
     ApplicationCreateRequest request =
@@ -81,11 +80,9 @@ class ProjectionTimeoutInMemoryTest {
     headers.set("X-Service-Name", "CIVIL_APPLY");
     headers.set("X-Schema-Version", "2");
 
-    long startMs = System.currentTimeMillis();
     ResponseEntity<Void> response =
         restTemplate.postForEntity(
             "/api/v0/applications", new HttpEntity<>(request, headers), Void.class);
-    long elapsedMs = System.currentTimeMillis() - startMs;
 
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
     assertThat(response.getHeaders().getETag()).isEqualTo("\"0\"");
@@ -100,24 +97,22 @@ class ProjectionTimeoutInMemoryTest {
                 applyApplicationId.toString()))
         .isEqualTo(1);
 
-    // The test must complete well below the full 5-second default timeout.
-    assertThat(elapsedMs).isLessThan(3_000L);
+    processor.start().join();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              ResponseEntity<ApplicationResponse> directRead =
+                  restTemplate.exchange(
+                      "/api/v0/applications/" + applyApplicationId,
+                      HttpMethod.GET,
+                      new HttpEntity<>(headers),
+                      ApplicationResponse.class);
 
-    CompletableFuture<Void> restart =
-        CompletableFuture.runAsync(
-            () -> processor.start().join(),
-            CompletableFuture.delayedExecutor(50, TimeUnit.MILLISECONDS));
-    ResponseEntity<ApplicationResponse> directRead =
-        restTemplate.exchange(
-            "/api/v0/applications/" + applyApplicationId,
-            HttpMethod.GET,
-            new HttpEntity<>(headers),
-            ApplicationResponse.class);
-
-    restart.join();
-    assertThat(directRead.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(directRead.getBody()).isNotNull();
-    assertThat(directRead.getBody().getApplicationId()).isEqualTo(applyApplicationId);
+              assertThat(directRead.getStatusCode()).isEqualTo(HttpStatus.OK);
+              assertThat(directRead.getBody()).isNotNull();
+              assertThat(directRead.getBody().getApplicationId()).isEqualTo(applyApplicationId);
+            });
   }
 
   @Test
@@ -202,16 +197,22 @@ class ProjectionTimeoutInMemoryTest {
                     "/api/v0/applications", new HttpEntity<>(createRequest, headers), Void.class)
                 .getStatusCode())
         .isEqualTo(HttpStatus.CREATED);
-    ApplicationResponse created =
-        restTemplate
-            .exchange(
-                "/api/v0/applications/" + applicationId,
-                HttpMethod.GET,
-                new HttpEntity<>(headers),
-                ApplicationResponse.class)
-            .getBody();
-    assertThat(created).isNotNull();
-    UUID proceedingId = created.getProceedings().getFirst().getProceedingId();
+    AtomicReference<ApplicationResponse> created = new AtomicReference<>();
+    await()
+        .atMost(Duration.ofSeconds(5))
+        .untilAsserted(
+            () -> {
+              ResponseEntity<ApplicationResponse> response =
+                  restTemplate.exchange(
+                      "/api/v0/applications/" + applicationId,
+                      HttpMethod.GET,
+                      new HttpEntity<>(headers),
+                      ApplicationResponse.class);
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              assertThat(response.getBody()).isNotNull();
+              created.set(response.getBody());
+            });
+    UUID proceedingId = created.get().getProceedings().getFirst().getProceedingId();
 
     StreamingEventProcessor processor =
         axonConfiguration

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/ProjectionTimeoutInMemoryTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/ProjectionTimeoutInMemoryTest.java
@@ -66,13 +66,13 @@ class ProjectionTimeoutInMemoryTest {
   @Autowired private JdbcTemplate jdbcTemplate;
 
   @Test
-  void givenStoppedProjectionProcessor_whenPostApplication_thenReturnsAcceptedWithLocation() {
-    // Stop the projection processor so no QueryUpdateEmitter.emit can be called for this command.
-    StreamingEventProcessor processor =
-        axonConfiguration
-            .getComponents(StreamingEventProcessor.class)
-            .get("application-projection");
-    processor.shutdown().join();
+  void givenStoppedProjectionProcessor_whenPostApplication_thenReturnsCreatedWithEtag() {
+    // Stop the projection processor to prove the command response does not wait for it.
+    axonConfiguration
+        .getComponents(StreamingEventProcessor.class)
+        .get("application-projection")
+        .shutdown()
+        .join();
 
     UUID applyApplicationId = UUID.randomUUID();
     ApplicationCreateRequest request =
@@ -87,8 +87,8 @@ class ProjectionTimeoutInMemoryTest {
             "/api/v0/applications", new HttpEntity<>(request, headers), Void.class);
     long elapsedMs = System.currentTimeMillis() - startMs;
 
-    // Command committed → 202 because projection never appeared within the 200 ms timeout.
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    assertThat(response.getHeaders().getETag()).isEqualTo("\"0\"");
     assertThat(response.getHeaders().getLocation()).isNotNull();
     assertThat(response.getHeaders().getLocation().getPath())
         .isEqualTo("/api/v0/applications/" + applyApplicationId);

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/CreateApplicationUseCaseTest.java
@@ -1,9 +1,5 @@
 package uk.gov.justice.laa.dstew.access.command.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -11,68 +7,46 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
-import uk.gov.justice.laa.dstew.access.query.SubscriptionProjectionGateway;
-import uk.gov.justice.laa.dstew.access.query.application.ApplicationReadModel;
-import uk.gov.justice.laa.dstew.access.query.application.FindApplicationByIdQuery;
 
 class CreateApplicationUseCaseTest {
 
   private RetryingCommandDispatcher dispatcher;
-  private SubscriptionProjectionGateway projectionGateway;
+  private ApplicationEventStorePositionRepository eventStorePositionRepository;
   private CreateApplicationUseCase useCase;
 
   @BeforeEach
   void setUp() {
     dispatcher = mock(RetryingCommandDispatcher.class);
-    projectionGateway = mock(SubscriptionProjectionGateway.class);
-    useCase = new CreateApplicationUseCase(dispatcher, projectionGateway);
+    eventStorePositionRepository = mock(ApplicationEventStorePositionRepository.class);
+    useCase = new CreateApplicationUseCase(dispatcher, eventStorePositionRepository);
   }
 
   @Test
-  void givenProjectionConfirmed_whenExecute_thenReturnsTrue() {
+  void givenCommittedCommand_whenExecute_thenReturnsAggregateSequence() {
     CreateApplicationCommand command = stubCommand();
-    when(projectionGateway.awaitProjection(any(), eq(ApplicationReadModel.class), any()))
-        .thenReturn(true);
+    when(dispatcher.dispatchAsync(command)).thenReturn(CompletableFuture.completedFuture(null));
+    when(eventStorePositionRepository.latestSequence(command.applicationId())).thenReturn(3L);
 
-    boolean result = useCase.execute(command);
+    ApplicationCommandResult result = useCase.execute(command).join();
 
-    assertThat(result).isTrue();
-    verify(projectionGateway)
-        .awaitProjection(
-            eq(new FindApplicationByIdQuery(command.applicationId())),
-            eq(ApplicationReadModel.class),
-            any());
+    org.assertj.core.api.Assertions.assertThat(result)
+        .isEqualTo(new ApplicationCommandResult(command.applicationId(), 3L));
   }
 
   @Test
-  void givenProjectionTimeout_whenExecute_thenReturnsFalse() {
+  void givenCommittedCommand_whenExecute_thenReadsCommittedSequenceAfterDispatch() {
     CreateApplicationCommand command = stubCommand();
-    when(projectionGateway.awaitProjection(any(), eq(ApplicationReadModel.class), any()))
-        .thenReturn(false);
+    when(dispatcher.dispatchAsync(command)).thenReturn(CompletableFuture.completedFuture(null));
+    when(eventStorePositionRepository.latestSequence(command.applicationId())).thenReturn(0L);
 
-    boolean result = useCase.execute(command);
+    useCase.execute(command).join();
 
-    assertThat(result).isFalse();
-  }
-
-  @Test
-  void givenProjection_whenExecute_thenDispatchesViaRetryingDispatcher() {
-    CreateApplicationCommand command = stubCommand();
-    doAnswer(
-            invocation -> {
-              Runnable action = invocation.getArgument(2);
-              action.run();
-              return true;
-            })
-        .when(projectionGateway)
-        .awaitProjection(any(), eq(ApplicationReadModel.class), any());
-
-    useCase.execute(command);
-
-    verify(dispatcher).dispatch(command);
+    verify(dispatcher).dispatchAsync(command);
+    verify(eventStorePositionRepository).latestSequence(command.applicationId());
   }
 
   private CreateApplicationCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/AssignCaseworkerUseCaseTest.java
@@ -9,24 +9,25 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.util.UUID;
-import org.axonframework.messaging.commandhandling.gateway.CommandGateway;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
 import uk.gov.justice.laa.dstew.access.command.caseworker.CaseworkerRepository;
 import uk.gov.justice.laa.dstew.access.exception.ResourceNotFoundException;
 
 class AssignCaseworkerUseCaseTest {
 
   private CaseworkerRepository caseworkerRepository;
-  private CommandGateway commandGateway;
+  private RetryingCommandDispatcher dispatcher;
   private AssignCaseworkerUseCase useCase;
 
   @BeforeEach
   void setUp() {
     caseworkerRepository = mock(CaseworkerRepository.class);
-    commandGateway = mock(CommandGateway.class);
-    useCase = new AssignCaseworkerUseCase(caseworkerRepository, commandGateway);
+    dispatcher = mock(RetryingCommandDispatcher.class);
+    useCase = new AssignCaseworkerUseCase(caseworkerRepository, dispatcher);
   }
 
   @Test
@@ -36,11 +37,14 @@ class AssignCaseworkerUseCaseTest {
     when(caseworkerRepository.existsById(caseworkerId)).thenReturn(true);
     Instant before = Instant.now();
 
-    useCase.assign(caseworkerId, applicationId, "request", "description");
+    when(dispatcher.dispatchAsync(org.mockito.ArgumentMatchers.any()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    useCase.assign(caseworkerId, applicationId, "request", "description").join();
 
     ArgumentCaptor<AssignCaseworkerToApplicationCommand> captor =
         ArgumentCaptor.forClass(AssignCaseworkerToApplicationCommand.class);
-    verify(commandGateway).sendAndWait(captor.capture());
+    verify(dispatcher).dispatchAsync(captor.capture());
     assertThat(captor.getValue())
         .satisfies(
             command -> {
@@ -61,6 +65,6 @@ class AssignCaseworkerUseCaseTest {
         .isInstanceOf(ResourceNotFoundException.class)
         .hasMessage("No caseworker found with id: " + caseworkerId);
 
-    verify(commandGateway, never()).sendAndWait(org.mockito.ArgumentMatchers.any());
+    verify(dispatcher, never()).dispatchAsync(org.mockito.ArgumentMatchers.any());
   }
 }

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/assignment/UnassignCaseworkerUseCaseTest.java
@@ -5,28 +5,37 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 
 class UnassignCaseworkerUseCaseTest {
 
   private RetryingCommandDispatcher dispatcher;
+  private ApplicationEventStorePositionRepository eventStorePositionRepository;
   private UnassignCaseworkerUseCase useCase;
 
   @BeforeEach
   void setUp() {
     dispatcher = mock(RetryingCommandDispatcher.class);
-    useCase = new UnassignCaseworkerUseCase(dispatcher);
+    eventStorePositionRepository = mock(ApplicationEventStorePositionRepository.class);
+    useCase = new UnassignCaseworkerUseCase(dispatcher, eventStorePositionRepository);
   }
 
   @Test
   void givenCommand_whenExecute_thenDelegatesToRetryingDispatcher() {
     UnassignCaseworkerFromApplicationCommand command = stubCommand();
 
-    useCase.execute(command);
+    org.mockito.Mockito.when(dispatcher.dispatchAsync(command))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    org.mockito.Mockito.when(eventStorePositionRepository.latestSequence(command.applicationId()))
+        .thenReturn(1L);
 
-    verify(dispatcher).dispatch(command);
+    useCase.execute(command).join();
+
+    verify(dispatcher).dispatchAsync(command);
   }
 
   private UnassignCaseworkerFromApplicationCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/decision/MakeApplicationDecisionUseCaseTest.java
@@ -6,28 +6,37 @@ import static org.mockito.Mockito.verify;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 
 class MakeApplicationDecisionUseCaseTest {
 
   private RetryingCommandDispatcher dispatcher;
+  private ApplicationEventStorePositionRepository eventStorePositionRepository;
   private MakeApplicationDecisionUseCase useCase;
 
   @BeforeEach
   void setUp() {
     dispatcher = mock(RetryingCommandDispatcher.class);
-    useCase = new MakeApplicationDecisionUseCase(dispatcher);
+    eventStorePositionRepository = mock(ApplicationEventStorePositionRepository.class);
+    useCase = new MakeApplicationDecisionUseCase(dispatcher, eventStorePositionRepository);
   }
 
   @Test
   void givenCommand_whenExecute_thenDelegatesToRetryingDispatcher() {
     MakeApplicationDecisionCommand command = stubCommand();
 
-    useCase.execute(command);
+    org.mockito.Mockito.when(dispatcher.dispatchAsync(command))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    org.mockito.Mockito.when(eventStorePositionRepository.latestSequence(command.applicationId()))
+        .thenReturn(1L);
 
-    verify(dispatcher).dispatch(command);
+    useCase.execute(command).join();
+
+    verify(dispatcher).dispatchAsync(command);
   }
 
   private MakeApplicationDecisionCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCaseTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/command/application/note/CreateNoteUseCaseTest.java
@@ -5,28 +5,37 @@ import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.dstew.access.command.RetryingCommandDispatcher;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 
 class CreateNoteUseCaseTest {
 
   private RetryingCommandDispatcher dispatcher;
+  private ApplicationEventStorePositionRepository eventStorePositionRepository;
   private CreateNoteUseCase useCase;
 
   @BeforeEach
   void setUp() {
     dispatcher = mock(RetryingCommandDispatcher.class);
-    useCase = new CreateNoteUseCase(dispatcher);
+    eventStorePositionRepository = mock(ApplicationEventStorePositionRepository.class);
+    useCase = new CreateNoteUseCase(dispatcher, eventStorePositionRepository);
   }
 
   @Test
   void givenCommand_whenExecute_thenDelegatesToRetryingDispatcher() {
     CreateNoteCommand command = stubCommand();
 
-    useCase.execute(command);
+    org.mockito.Mockito.when(dispatcher.dispatchAsync(command))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    org.mockito.Mockito.when(eventStorePositionRepository.latestSequence(command.applicationId()))
+        .thenReturn(1L);
 
-    verify(dispatcher).dispatch(command);
+    useCase.execute(command).join();
+
+    verify(dispatcher).dispatchAsync(command);
   }
 
   private CreateNoteCommand stubCommand() {

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandControllerTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/controller/application/ApplicationCommandControllerTest.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationCommandResult;
 import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationCommand;
 import uk.gov.justice.laa.dstew.access.command.application.CreateApplicationUseCase;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.AssignCaseworkerUseCase;
@@ -136,23 +138,19 @@ class ApplicationCommandControllerTest {
   }
 
   @Test
-  void givenProjectedResult_whenCreateApplication_thenDelegatesToUseCaseAndReturns201() {
+  void givenCommittedCommand_whenCreateApplication_thenDelegatesToUseCaseAndReturns201() {
     CreateApplicationCommand command = stubCreateCommand();
     when(commandMapper.toCommand(any(), anyInt())).thenReturn(command);
-    when(createApplicationUseCase.execute(command)).thenReturn(true);
-    ResponseEntity<Void> response = controller.createApplication(null, 1, null);
+    when(createApplicationUseCase.execute(command))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new ApplicationCommandResult(command.applicationId(), 3L)));
+
+    ResponseEntity<Void> response = controller.createApplication(null, 1, null).join();
+
     verify(createApplicationUseCase).execute(command);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-  }
-
-  @Test
-  void givenTimeoutResult_whenCreateApplication_thenDelegatesToUseCaseAndReturns202() {
-    CreateApplicationCommand command = stubCreateCommand();
-    when(commandMapper.toCommand(any(), anyInt())).thenReturn(command);
-    when(createApplicationUseCase.execute(command)).thenReturn(false);
-    ResponseEntity<Void> response = controller.createApplication(null, 1, null);
-    verify(createApplicationUseCase).execute(command);
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+    assertThat(response.getHeaders().getETag()).isEqualTo("\"3\"");
   }
 
   @Test
@@ -160,8 +158,13 @@ class ApplicationCommandControllerTest {
     UUID id = UUID.randomUUID();
     MakeApplicationDecisionCommand command = mock(MakeApplicationDecisionCommand.class);
     when(decisionCommandMapper.toCommand(id, null)).thenReturn(command);
-    controller.makeDecision(null, id, null);
+    when(makeDecisionUseCase.execute(command))
+        .thenReturn(CompletableFuture.completedFuture(new ApplicationCommandResult(id, 3L)));
+
+    ResponseEntity<Void> response = controller.makeDecision(null, id, null).join();
+
     verify(makeDecisionUseCase).execute(command);
+    assertThat(response.getHeaders().getETag()).isEqualTo("\"3\"");
   }
 
   @Test
@@ -169,8 +172,13 @@ class ApplicationCommandControllerTest {
     UUID id = UUID.randomUUID();
     CreateNoteCommand command = mock(CreateNoteCommand.class);
     when(createNoteCommandMapper.toCommand(id, null)).thenReturn(command);
-    controller.createNote(null, id, null);
+    when(createNoteUseCase.execute(command))
+        .thenReturn(CompletableFuture.completedFuture(new ApplicationCommandResult(id, 3L)));
+
+    ResponseEntity<Void> response = controller.createNote(null, id, null).join();
+
     verify(createNoteUseCase).execute(command);
+    assertThat(response.getHeaders().getETag()).isEqualTo("\"3\"");
   }
 
   @Test
@@ -179,8 +187,13 @@ class ApplicationCommandControllerTest {
     UnassignCaseworkerFromApplicationCommand command =
         mock(UnassignCaseworkerFromApplicationCommand.class);
     when(unassignCaseworkerRequestMapper.toCommand(id, null)).thenReturn(command);
-    controller.unassignCaseworker(null, id, null);
+    when(unassignCaseworkerUseCase.execute(command))
+        .thenReturn(CompletableFuture.completedFuture(new ApplicationCommandResult(id, 3L)));
+
+    ResponseEntity<Void> response = controller.unassignCaseworker(null, id, null).join();
+
     verify(unassignCaseworkerUseCase).execute(command);
+    assertThat(response.getHeaders().getETag()).isEqualTo("\"3\"");
   }
 
   @Test
@@ -188,13 +201,22 @@ class ApplicationCommandControllerTest {
     CaseworkerAssignment assignment =
         new CaseworkerAssignment(UUID.randomUUID(), UUID.randomUUID(), "{}", "desc");
     when(assignCaseworkerRequestMapper.toAssignment(any())).thenReturn(assignment);
-    controller.assignCaseworker(null, null);
+    when(assignCaseworkerUseCase.assign(
+            assignment.caseworkerId(),
+            assignment.applicationId(),
+            assignment.serialisedRequest(),
+            assignment.eventDescription()))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    ResponseEntity<Void> response = controller.assignCaseworker(null, null).join();
+
     verify(assignCaseworkerUseCase)
         .assign(
             assignment.caseworkerId(),
             assignment.applicationId(),
             assignment.serialisedRequest(),
             assignment.eventDescription());
+    assertThat(response.getHeaders().getETag()).isNull();
     verify(makeDecisionUseCase, never()).execute(any());
     verify(createNoteUseCase, never()).execute(any());
     verify(unassignCaseworkerUseCase, never()).execute(any());

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
+import org.axonframework.messaging.eventhandling.EventMessage;
 import org.axonframework.messaging.queryhandling.QueryUpdateEmitter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationCreatedEvent;
+import uk.gov.justice.laa.dstew.access.command.application.ApplicationEventStorePositionRepository;
 import uk.gov.justice.laa.dstew.access.command.application.ApplicationLinkedEvent;
 import uk.gov.justice.laa.dstew.access.command.application.AutoGrantedState;
 import uk.gov.justice.laa.dstew.access.command.application.assignment.ApplicationAssignedToCaseworkerEvent;
@@ -43,19 +45,23 @@ import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationLi
 class ApplicationProjectionTest {
 
   private ApplicationReadRepository applicationReadRepository;
+  private ApplicationEventStorePositionRepository eventStorePositionRepository;
   private LinkedApplicationGroupReadRepository groupReadRepository;
   private QueryUpdateEmitter queryUpdateEmitter;
   private ApplicationDataStore applicationDataStore;
   private ApplicationListIndexReadRepository listIndexRepository;
+  private EventMessage eventMessage;
   private ApplicationProjection projection;
 
   @BeforeEach
   void setUp() {
     applicationReadRepository = mock(ApplicationReadRepository.class);
+    eventStorePositionRepository = mock(ApplicationEventStorePositionRepository.class);
     groupReadRepository = mock(LinkedApplicationGroupReadRepository.class);
     queryUpdateEmitter = mock(QueryUpdateEmitter.class);
     applicationDataStore = mock(ApplicationDataStore.class);
     listIndexRepository = mock(ApplicationListIndexReadRepository.class);
+    eventMessage = mock(EventMessage.class);
     when(applicationDataStore.get(any(), anyLong()))
         .thenAnswer(
             invocation ->
@@ -63,6 +69,7 @@ class ApplicationProjectionTest {
     projection =
         new ApplicationProjection(
             applicationReadRepository,
+            eventStorePositionRepository,
             groupReadRepository,
             applicationDataStore,
             listIndexRepository);
@@ -76,7 +83,7 @@ class ApplicationProjectionTest {
         ApplicationReadModel.builder().applicationId(applicationId).build();
     when(applicationReadRepository.save(any())).thenReturn(saved);
 
-    projection.on(event, queryUpdateEmitter);
+    projection.on(event, eventMessage, queryUpdateEmitter);
 
     InOrder order = inOrder(applicationReadRepository, queryUpdateEmitter);
     order.verify(applicationReadRepository).save(any());
@@ -104,7 +111,7 @@ class ApplicationProjectionTest {
     when(applicationReadRepository.save(any()))
         .thenReturn(ApplicationReadModel.builder().applicationId(applicationId).build());
 
-    projection.on(event, queryUpdateEmitter);
+    projection.on(event, eventMessage, queryUpdateEmitter);
 
     assertThat(capturedPredicate[0]).isNotNull();
     Predicate<FindApplicationByIdQuery> predicate =
@@ -162,7 +169,7 @@ class ApplicationProjectionTest {
     ApplicationLinkedEvent event =
         new ApplicationLinkedEvent(applicationId, leadApplicationId, Instant.now());
 
-    projection.on(event);
+    projection.on(event, eventMessage);
 
     assertThat(existing.getLeadApplicationId()).isEqualTo(leadApplicationId);
     verify(applicationReadRepository).save(existing);
@@ -218,7 +225,8 @@ class ApplicationProjectionTest {
     when(applicationReadRepository.findById(applicationId)).thenReturn(Optional.of(existing));
 
     projection.on(
-        new ApplicationAssignedToCaseworkerEvent(applicationId, 1L, 2L, caseworkerId, occurredAt));
+        new ApplicationAssignedToCaseworkerEvent(applicationId, 1L, 2L, caseworkerId, occurredAt),
+        eventMessage);
 
     assertThat(existing.getCaseworkerId()).isEqualTo(caseworkerId);
     assertThat(existing.getApplicationVersion()).isEqualTo(1L);
@@ -238,7 +246,9 @@ class ApplicationProjectionTest {
             .build();
     when(applicationReadRepository.findById(applicationId)).thenReturn(Optional.of(existing));
 
-    projection.on(new ApplicationUnassignedFromCaseworkerEvent(applicationId, 2L, 3L, occurredAt));
+    projection.on(
+        new ApplicationUnassignedFromCaseworkerEvent(applicationId, 2L, 3L, occurredAt),
+        eventMessage);
 
     assertThat(existing.getCaseworkerId()).isNull();
     assertThat(existing.getApplicationVersion()).isEqualTo(2L);
@@ -262,7 +272,8 @@ class ApplicationProjectionTest {
 
     projection.on(
         new uk.gov.justice.laa.dstew.access.command.application.note.NoteCreatedEvent(
-            applicationId, 1L, occurredAt));
+            applicationId, 1L, occurredAt),
+        eventMessage);
 
     assertThat(existing.getApplicationDataVersion()).isEqualTo(1L);
     assertThat(existing.getApplicationVersion()).isEqualTo(0L);

--- a/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
+++ b/data-access-service-axon/src/test/java/uk/gov/justice/laa/dstew/access/query/application/ApplicationProjectionTest.java
@@ -38,6 +38,7 @@ import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationDataS
 import uk.gov.justice.laa.dstew.access.command.application.data.ApplicationNote;
 import uk.gov.justice.laa.dstew.access.command.application.decision.ApplicationDecisionMadeEvent;
 import uk.gov.justice.laa.dstew.access.command.application.ready.ApplicationReadyForManualAssessmentEvent;
+import uk.gov.justice.laa.dstew.access.command.application.update.ApplicationUpdatedEvent;
 import uk.gov.justice.laa.dstew.access.query.application.linkedgroup.LinkedApplicationGroupReadRepository;
 import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexReadModel;
 import uk.gov.justice.laa.dstew.access.query.application.listindex.ApplicationListIndexReadRepository;
@@ -191,6 +192,40 @@ class ApplicationProjectionTest {
 
     assertThat(existing.getApplicationVersion()).isEqualTo(3L);
     assertThat(existing.getApplicationDataVersion()).isEqualTo(4L);
+    assertThat(existing.getModifiedAt()).isEqualTo(occurredAt);
+    verify(queryUpdateEmitter)
+        .emit(any(Class.class), any(Predicate.class), any(ApplicationReadModel.class));
+  }
+
+  @Test
+  void givenUpdatedEvent_whenHandled_thenAdvancesStateSequenceAndEmitsUpdate() {
+    UUID applicationId = UUID.randomUUID();
+    Instant occurredAt = Instant.parse("2026-07-20T08:00:00Z");
+    ApplicationReadModel existing =
+        ApplicationReadModel.builder().applicationId(applicationId).build();
+    when(applicationReadRepository.findById(applicationId)).thenReturn(Optional.of(existing));
+    when(applicationReadRepository.save(existing)).thenReturn(existing);
+    when(eventMessage.identifier()).thenReturn("event-message-id");
+    when(eventStorePositionRepository.sequenceForEvent(applicationId, "event-message-id"))
+        .thenReturn(7L);
+
+    projection.on(
+        new ApplicationUpdatedEvent(
+            applicationId,
+            3L,
+            4L,
+            "APPLICATION_DRAFT",
+            "APPLICATION_SUBMITTED",
+            "CERTIFICATED",
+            applicationId,
+            occurredAt),
+        eventMessage,
+        queryUpdateEmitter);
+
+    assertThat(existing.getStatus()).isEqualTo("APPLICATION_SUBMITTED");
+    assertThat(existing.getApplicationVersion()).isEqualTo(3L);
+    assertThat(existing.getApplicationDataVersion()).isEqualTo(4L);
+    assertThat(existing.getAggregateSequence()).isEqualTo(7L);
     assertThat(existing.getModifiedAt()).isEqualTo(occurredAt);
     verify(queryUpdateEmitter)
         .emit(any(Class.class), any(Predicate.class), any(ApplicationReadModel.class));


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-2081)

Updated the application post commands, except assign caseworker to be async and return a eTag with the sequence number of the event in the event store. Updated the Get Application endpoint to take this sequence number and to check it against the ApplicationReadModel projection to determine if the projection is up to date on the request.

If not return a 202 to prompt the client to retry else return the Application as normal

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test integrationTest`
- [ ] CheckStyle should not error: `./gradlew checkStyleMain`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
